### PR TITLE
feat(vehicles): add infrastructure layer (Phase 4)

### DIFF
--- a/apps/api/src/vehicles/infrastructure/controllers/Vehicle.controller.spec.ts
+++ b/apps/api/src/vehicles/infrastructure/controllers/Vehicle.controller.spec.ts
@@ -1,0 +1,241 @@
+import { Test } from '@nestjs/testing'
+import type { Mock } from 'bun:test'
+import { beforeEach, describe, expect, it, mock } from 'bun:test'
+
+import type { AuthSession } from '~/auth/domain/types'
+import {
+  CreateVehicleDto,
+  GetVehicleDto,
+  UpdateMileageDto,
+  UpdateVehicleDto
+} from '~/vehicles/application/dtos'
+import { VehicleService } from '~/vehicles/application/services'
+import { FuelType } from '~/vehicles/domain/entities'
+import { VehicleIdValueObject } from '~/vehicles/domain/value-objects'
+
+import { VehicleController } from './Vehicle.controller'
+
+describe('VehicleController', () => {
+  let controller: VehicleController
+  let mockVehicleService: {
+    createVehicle: Mock<typeof VehicleService.prototype.createVehicle>
+    getVehicleByUser: Mock<typeof VehicleService.prototype.getVehicleByUser>
+    updateVehicle: Mock<typeof VehicleService.prototype.updateVehicle>
+    updateMileage: Mock<typeof VehicleService.prototype.updateMileage>
+    deleteVehicle: Mock<typeof VehicleService.prototype.deleteVehicle>
+  }
+
+  const createMockSession = (userId: string): AuthSession => ({
+    session: { id: 'session-id', userId, expiresAt: new Date() },
+    user: {
+      id: userId,
+      email: 'test@example.com',
+      emailVerified: true,
+      username: 'testuser',
+      firstName: 'Test',
+      lastName: 'User',
+      role: 'user',
+      banned: false,
+      banReason: null,
+      banExpires: null,
+      createdAt: new Date(),
+      updatedAt: new Date()
+    }
+  })
+
+  const createMockGetVehicleDto = (overrides = {}): GetVehicleDto => {
+    const dto = new GetVehicleDto()
+    Object.assign(dto, {
+      id: '123e4567-e89b-12d3-a456-426614174000',
+      userId: '123e4567-e89b-12d3-a456-426614174001',
+      make: 'Toyota',
+      model: 'Camry',
+      year: 2020,
+      engineType: 'V6',
+      fuelType: FuelType.GASOLINE,
+      vin: '1HGCM82633A004352',
+      licensePlate: 'ABC123',
+      purchaseDate: new Date('2025-01-01'),
+      mileage: 15000,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      ...overrides
+    })
+    return dto
+  }
+
+  beforeEach(async () => {
+    mockVehicleService = {
+      createVehicle: mock(() => {}) as unknown as Mock<
+        typeof VehicleService.prototype.createVehicle
+      >,
+      getVehicleByUser: mock(() => {}) as unknown as Mock<
+        typeof VehicleService.prototype.getVehicleByUser
+      >,
+      updateVehicle: mock(() => {}) as unknown as Mock<
+        typeof VehicleService.prototype.updateVehicle
+      >,
+      updateMileage: mock(() => {}) as unknown as Mock<
+        typeof VehicleService.prototype.updateMileage
+      >,
+      deleteVehicle: mock(() => {}) as unknown as Mock<
+        typeof VehicleService.prototype.deleteVehicle
+      >
+    }
+
+    const module = await Test.createTestingModule({
+      controllers: [VehicleController],
+      providers: [
+        {
+          provide: VehicleService,
+          useValue: mockVehicleService
+        }
+      ]
+    }).compile()
+
+    controller = module.get<VehicleController>(VehicleController)
+
+    // Clear all mocks
+    mockVehicleService.createVehicle.mockClear()
+    mockVehicleService.getVehicleByUser.mockClear()
+    mockVehicleService.updateVehicle.mockClear()
+    mockVehicleService.updateMileage.mockClear()
+    mockVehicleService.deleteVehicle.mockClear()
+  })
+
+  describe('create', () => {
+    it('should create a vehicle for the authenticated user', async () => {
+      const dto = new CreateVehicleDto()
+      Object.assign(dto, {
+        make: 'Toyota',
+        model: 'Camry',
+        year: 2020,
+        engineType: 'V6',
+        fuelType: FuelType.GASOLINE,
+        vin: '1HGCM82633A004352',
+        licensePlate: 'ABC123',
+        purchaseDate: new Date('2025-01-01'),
+        mileage: 15000
+      })
+      const session = createMockSession('123e4567-e89b-12d3-a456-426614174001')
+      const expectedDto = createMockGetVehicleDto({
+        userId: session.user.id,
+        make: dto.make,
+        model: dto.model,
+        year: dto.year,
+        engineType: dto.engineType,
+        fuelType: dto.fuelType,
+        vin: dto.vin,
+        licensePlate: dto.licensePlate,
+        purchaseDate: dto.purchaseDate,
+        mileage: dto.mileage
+      })
+
+      mockVehicleService.createVehicle.mockResolvedValue(expectedDto)
+
+      const result = await controller.create(session, dto)
+
+      expect(mockVehicleService.createVehicle).toHaveBeenCalledWith(dto, session.user.id)
+      expect(result).toEqual(expectedDto)
+    })
+  })
+
+  describe('getMyVehicle', () => {
+    it('should return the user vehicle', async () => {
+      const session = createMockSession('123e4567-e89b-12d3-a456-426614174001')
+      const expectedDto = createMockGetVehicleDto({ userId: session.user.id })
+
+      mockVehicleService.getVehicleByUser.mockResolvedValue(expectedDto)
+
+      const result = await controller.getMyVehicle(session)
+
+      expect(mockVehicleService.getVehicleByUser).toHaveBeenCalledWith(session.user.id)
+      expect(result).toEqual(expectedDto)
+    })
+
+    it('should return null when user has no vehicle', async () => {
+      const session = createMockSession('123e4567-e89b-12d3-a456-426614174001')
+
+      mockVehicleService.getVehicleByUser.mockResolvedValue(null)
+
+      const result = await controller.getMyVehicle(session)
+
+      expect(mockVehicleService.getVehicleByUser).toHaveBeenCalledWith(session.user.id)
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('update', () => {
+    it('should update vehicle details', async () => {
+      const dto = new UpdateVehicleDto()
+      Object.assign(dto, {
+        make: 'Honda',
+        model: 'Civic',
+        year: 2021,
+        engineType: 'I4',
+        fuelType: FuelType.GASOLINE,
+        vin: '2HGCM82633A004353',
+        licensePlate: 'XYZ789',
+        purchaseDate: new Date('2025-06-01')
+      })
+      const session = createMockSession('123e4567-e89b-12d3-a456-426614174001')
+      const vehicleId = '123e4567-e89b-12d3-a456-426614174000'
+      const expectedDto = createMockGetVehicleDto({
+        id: vehicleId,
+        userId: session.user.id,
+        make: dto.make,
+        model: dto.model,
+        year: dto.year,
+        engineType: dto.engineType,
+        fuelType: dto.fuelType,
+        vin: dto.vin,
+        licensePlate: dto.licensePlate,
+        purchaseDate: dto.purchaseDate
+      })
+
+      mockVehicleService.updateVehicle.mockResolvedValue(expectedDto)
+
+      const result = await controller.update(session, vehicleId, dto)
+
+      expect(mockVehicleService.updateVehicle).toHaveBeenCalledWith(vehicleId, session.user.id, dto)
+      expect(result).toEqual(expectedDto)
+    })
+  })
+
+  describe('updateMileage', () => {
+    it('should update vehicle mileage', async () => {
+      const dto = new UpdateMileageDto()
+      Object.assign(dto, { mileage: 20000 })
+      const session = createMockSession('123e4567-e89b-12d3-a456-426614174001')
+      const vehicleId = '123e4567-e89b-12d3-a456-426614174000'
+      const expectedDto = createMockGetVehicleDto({
+        id: vehicleId,
+        userId: session.user.id,
+        mileage: dto.mileage
+      })
+
+      mockVehicleService.updateMileage.mockResolvedValue(expectedDto)
+
+      const result = await controller.updateMileage(session, vehicleId, dto)
+
+      expect(mockVehicleService.updateMileage).toHaveBeenCalledWith(vehicleId, session.user.id, dto)
+      expect(result).toEqual(expectedDto)
+    })
+  })
+
+  describe('delete', () => {
+    it('should delete the vehicle', async () => {
+      const session = createMockSession('123e4567-e89b-12d3-a456-426614174001')
+      const vehicleId = new VehicleIdValueObject('123e4567-e89b-12d3-a456-426614174000')
+
+      mockVehicleService.deleteVehicle.mockResolvedValue()
+
+      await controller.delete(session, vehicleId.value)
+
+      expect(mockVehicleService.deleteVehicle).toHaveBeenCalledWith(
+        vehicleId.value,
+        session.user.id
+      )
+    })
+  })
+})

--- a/apps/api/src/vehicles/infrastructure/controllers/Vehicle.controller.ts
+++ b/apps/api/src/vehicles/infrastructure/controllers/Vehicle.controller.ts
@@ -1,0 +1,68 @@
+import { Body, Controller, Delete, Get, Param, Patch, Post } from '@nestjs/common'
+import { Session } from '@thallesp/nestjs-better-auth'
+
+import type { AuthSession } from '~/auth/domain/types'
+import type {
+  CreateVehicleDto,
+  GetVehicleDto,
+  UpdateMileageDto,
+  UpdateVehicleDto
+} from '~/vehicles/application/dtos'
+import { VehicleService } from '~/vehicles/application/services'
+
+@Controller('vehicles')
+export class VehicleController {
+  constructor(private readonly vehicleService: VehicleService) {}
+
+  @Post()
+  async create(
+    @Session() session: AuthSession,
+    @Body() createDto: CreateVehicleDto
+  ): Promise<GetVehicleDto> {
+    const newVehicle = await this.vehicleService.createVehicle(createDto, session.user.id)
+
+    return newVehicle
+  }
+
+  @Get('me')
+  async getMyVehicle(@Session() session: AuthSession): Promise<GetVehicleDto | null> {
+    const vehicle = await this.vehicleService.getVehicleByUser(session.user.id)
+
+    return vehicle
+  }
+
+  @Patch(':id')
+  async update(
+    @Session() session: AuthSession,
+    @Param('id') vehicleId: string,
+    @Body() updateDto: UpdateVehicleDto
+  ): Promise<GetVehicleDto> {
+    const updatedVehicle = await this.vehicleService.updateVehicle(
+      vehicleId,
+      session.user.id,
+      updateDto
+    )
+
+    return updatedVehicle
+  }
+
+  @Patch(':id/mileage')
+  async updateMileage(
+    @Session() session: AuthSession,
+    @Param('id') vehicleId: string,
+    @Body() updateMileageDto: UpdateMileageDto
+  ): Promise<GetVehicleDto> {
+    const updatedVehicle = await this.vehicleService.updateMileage(
+      vehicleId,
+      session.user.id,
+      updateMileageDto
+    )
+
+    return updatedVehicle
+  }
+
+  @Delete(':id')
+  async delete(@Session() session: AuthSession, @Param('id') vehicleId: string): Promise<void> {
+    await this.vehicleService.deleteVehicle(vehicleId, session.user.id)
+  }
+}

--- a/apps/api/src/vehicles/infrastructure/controllers/index.ts
+++ b/apps/api/src/vehicles/infrastructure/controllers/index.ts
@@ -1,0 +1,1 @@
+export { VehicleController } from './Vehicle.controller'

--- a/apps/api/src/vehicles/infrastructure/mappers/VehicleInfra.mapper.spec.ts
+++ b/apps/api/src/vehicles/infrastructure/mappers/VehicleInfra.mapper.spec.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from 'bun:test'
+
+import { FuelType as PrismaFuelType } from '@generated'
+
+import { FuelType, VehicleEntity } from '~/vehicles/domain/entities'
+import {
+  MileageValueObject,
+  VehicleIdValueObject,
+  VinValueObject,
+  YearValueObject
+} from '~/vehicles/domain/value-objects'
+
+import { VehicleInfrastructureMapper } from './VehicleInfra.mapper'
+
+describe('VehicleInfrastructureMapper', () => {
+  describe('toDomain', () => {
+    it('should map PrismaVehicle to VehicleEntity with all fields', () => {
+      const prismaVehicle = {
+        id: '123e4567-e89b-12d3-a456-426614174000',
+        userId: '123e4567-e89b-12d3-a456-426614174000',
+        make: 'Toyota',
+        model: 'Camry',
+        year: 2020,
+        engineType: 'V6',
+        fuelType: PrismaFuelType.GASOLINE,
+        vin: '1HGCM82633A004352',
+        licensePlate: 'ABC123',
+        purchaseDate: new Date('2025-01-01T00:00:00Z'),
+        mileage: 15000,
+        createdAt: new Date('2026-01-01T00:00:00Z'),
+        updatedAt: new Date('2026-01-02T00:00:00Z')
+      }
+
+      const result = VehicleInfrastructureMapper.toDomain(prismaVehicle)
+
+      expect(result).toBeInstanceOf(VehicleEntity)
+      expect(result.id).toBeInstanceOf(VehicleIdValueObject)
+      expect(result.id.value).toBe('123e4567-e89b-12d3-a456-426614174000')
+      expect(result.userId).toBe('123e4567-e89b-12d3-a456-426614174000')
+      expect(result.make).toBe('Toyota')
+      expect(result.model).toBe('Camry')
+      expect(result.year).toBeInstanceOf(YearValueObject)
+      expect(result.year.value).toBe(2020)
+      expect(result.engineType).toBe('V6')
+      expect(result.fuelType).toBe(FuelType.GASOLINE)
+      expect(result.vin).toBeInstanceOf(VinValueObject)
+      expect(result.vin?.value).toBe('1HGCM82633A004352')
+      expect(result.licensePlate).toBe('ABC123')
+      expect(result.purchaseDate).toEqual(new Date('2025-01-01T00:00:00Z'))
+      expect(result.mileage).toBeInstanceOf(MileageValueObject)
+      expect(result.mileage.value).toBe(15000)
+      expect(result.createdAt).toEqual(new Date('2026-01-01T00:00:00Z'))
+      expect(result.updatedAt).toEqual(new Date('2026-01-02T00:00:00Z'))
+    })
+
+    it('should map PrismaVehicle to VehicleEntity with null optional fields', () => {
+      const prismaVehicle = {
+        id: '123e4567-e89b-12d3-a456-426614174000',
+        userId: '123e4567-e89b-12d3-a456-426614174000',
+        make: 'Toyota',
+        model: 'Camry',
+        year: 2020,
+        engineType: 'V6',
+        fuelType: null,
+        vin: null,
+        licensePlate: 'ABC123',
+        purchaseDate: new Date('2025-01-01T00:00:00Z'),
+        mileage: 15000,
+        createdAt: new Date('2026-01-01T00:00:00Z'),
+        updatedAt: new Date('2026-01-02T00:00:00Z')
+      }
+
+      const result = VehicleInfrastructureMapper.toDomain(prismaVehicle)
+
+      expect(result).toBeInstanceOf(VehicleEntity)
+      expect(result.vin).toBeNull()
+      expect(result.fuelType).toBeNull()
+    })
+  })
+
+  describe('toPrisma', () => {
+    it('should map VehicleEntity to Prisma data with all fields', () => {
+      const vehicleEntity = new VehicleEntity(
+        new VehicleIdValueObject('123e4567-e89b-12d3-a456-426614174000'),
+        '123e4567-e89b-12d3-a456-426614174000',
+        'Toyota',
+        'Camry',
+        new YearValueObject(2020),
+        'V6',
+        FuelType.GASOLINE,
+        new VinValueObject('1HGCM82633A004352'),
+        'ABC123',
+        new Date('2025-01-01T00:00:00Z'),
+        new MileageValueObject(15000),
+        new Date('2026-01-01T00:00:00Z'),
+        new Date('2026-01-02T00:00:00Z')
+      )
+
+      const result = VehicleInfrastructureMapper.toPrisma(vehicleEntity)
+
+      expect(result).toEqual({
+        id: '123e4567-e89b-12d3-a456-426614174000',
+        userId: '123e4567-e89b-12d3-a456-426614174000',
+        make: 'Toyota',
+        model: 'Camry',
+        year: 2020,
+        engineType: 'V6',
+        fuelType: PrismaFuelType.GASOLINE,
+        vin: '1HGCM82633A004352',
+        licensePlate: 'ABC123',
+        purchaseDate: new Date('2025-01-01T00:00:00Z'),
+        mileage: 15000,
+        createdAt: new Date('2026-01-01T00:00:00Z'),
+        updatedAt: new Date('2026-01-02T00:00:00Z')
+      })
+    })
+
+    it('should map VehicleEntity to Prisma data with null optional fields', () => {
+      const vehicleEntity = new VehicleEntity(
+        new VehicleIdValueObject('123e4567-e89b-12d3-a456-426614174000'),
+        '123e4567-e89b-12d3-a456-426614174000',
+        'Toyota',
+        'Camry',
+        new YearValueObject(2020),
+        'V6',
+        null,
+        null,
+        'ABC123',
+        new Date('2025-01-01T00:00:00Z'),
+        new MileageValueObject(15000),
+        new Date('2026-01-01T00:00:00Z'),
+        new Date('2026-01-02T00:00:00Z')
+      )
+
+      const result = VehicleInfrastructureMapper.toPrisma(vehicleEntity)
+
+      expect(result).toEqual({
+        id: '123e4567-e89b-12d3-a456-426614174000',
+        userId: '123e4567-e89b-12d3-a456-426614174000',
+        make: 'Toyota',
+        model: 'Camry',
+        year: 2020,
+        engineType: 'V6',
+        fuelType: null,
+        vin: null,
+        licensePlate: 'ABC123',
+        purchaseDate: new Date('2025-01-01T00:00:00Z'),
+        mileage: 15000,
+        createdAt: new Date('2026-01-01T00:00:00Z'),
+        updatedAt: new Date('2026-01-02T00:00:00Z')
+      })
+    })
+  })
+})

--- a/apps/api/src/vehicles/infrastructure/mappers/VehicleInfra.mapper.ts
+++ b/apps/api/src/vehicles/infrastructure/mappers/VehicleInfra.mapper.ts
@@ -1,0 +1,52 @@
+import type { Vehicle as PrismaVehicle } from '@generated'
+
+import type { FuelType } from '~/vehicles/domain/entities'
+import { VehicleEntity } from '~/vehicles/domain/entities'
+import {
+  MileageValueObject,
+  VehicleIdValueObject,
+  VinValueObject,
+  YearValueObject
+} from '~/vehicles/domain/value-objects'
+
+export class VehicleInfrastructureMapper {
+  static toDomain(prismaVehicle: PrismaVehicle): VehicleEntity {
+    const vehicleEntity = new VehicleEntity(
+      new VehicleIdValueObject(prismaVehicle.id),
+      prismaVehicle.userId,
+      prismaVehicle.make,
+      prismaVehicle.model,
+      new YearValueObject(prismaVehicle.year),
+      prismaVehicle.engineType,
+      prismaVehicle.fuelType as FuelType,
+      prismaVehicle.vin ? new VinValueObject(prismaVehicle.vin) : null,
+      prismaVehicle.licensePlate,
+      prismaVehicle.purchaseDate,
+      new MileageValueObject(prismaVehicle.mileage),
+      prismaVehicle.createdAt,
+      prismaVehicle.updatedAt
+    )
+
+    return vehicleEntity
+  }
+
+  static toPrisma(vehicleEntity: VehicleEntity): Omit<PrismaVehicle, 'user'> {
+    const prismaVehicle: Omit<PrismaVehicle, 'user'> = {
+      id: vehicleEntity.id.value,
+      userId: vehicleEntity.userId,
+      make: vehicleEntity.make,
+      model: vehicleEntity.model,
+      year: vehicleEntity.year.value,
+      engineType: vehicleEntity.engineType,
+      fuelType: vehicleEntity.fuelType as PrismaVehicle['fuelType'],
+      vin: vehicleEntity.vin ? vehicleEntity.vin.value : null,
+      licensePlate: vehicleEntity.licensePlate,
+      purchaseDate: vehicleEntity.purchaseDate,
+      mileage: vehicleEntity.mileage.value,
+      createdAt: vehicleEntity.createdAt,
+      updatedAt: vehicleEntity.updatedAt
+    }
+
+    return prismaVehicle
+  }
+}

--- a/apps/api/src/vehicles/infrastructure/mappers/index.ts
+++ b/apps/api/src/vehicles/infrastructure/mappers/index.ts
@@ -1,0 +1,1 @@
+export { VehicleInfrastructureMapper } from './VehicleInfra.mapper'

--- a/apps/api/src/vehicles/infrastructure/repositories/PrismaVehicle.repository.spec.ts
+++ b/apps/api/src/vehicles/infrastructure/repositories/PrismaVehicle.repository.spec.ts
@@ -1,0 +1,257 @@
+import type { Mock } from 'bun:test'
+import { beforeEach, describe, expect, it, mock } from 'bun:test'
+
+import { Prisma, FuelType as PrismaFuelType } from '@generated'
+
+import type { PrismaProvider } from '~/shared/infrastructure/database'
+import { FuelType, VehicleEntity } from '~/vehicles/domain/entities'
+import {
+  VehicleAlreadyExistsException,
+  VehicleNotFoundException
+} from '~/vehicles/domain/exceptions'
+import {
+  MileageValueObject,
+  VehicleIdValueObject,
+  VinValueObject,
+  YearValueObject
+} from '~/vehicles/domain/value-objects'
+
+import { VehicleInfrastructureMapper } from '../mappers'
+
+import { PrismaVehicleRepository } from './PrismaVehicle.repository'
+
+describe('PrismaVehicleRepository', () => {
+  let repository: PrismaVehicleRepository
+  let mockPrismaService: {
+    vehicle: {
+      create: Mock<PrismaProvider['vehicle']['create']>
+      findUnique: Mock<PrismaProvider['vehicle']['findUnique']>
+      findMany: Mock<PrismaProvider['vehicle']['findMany']>
+      findFirst: Mock<PrismaProvider['vehicle']['findFirst']>
+      update: Mock<PrismaProvider['vehicle']['update']>
+      delete: Mock<PrismaProvider['vehicle']['delete']>
+    }
+  }
+
+  const createMockPrismaVehicle = (overrides = {}) => ({
+    id: '123e4567-e89b-12d3-a456-426614174000',
+    userId: '123e4567-e89b-12d3-a456-426614174001',
+    make: 'Toyota',
+    model: 'Camry',
+    year: 2020,
+    engineType: 'V6',
+    fuelType: PrismaFuelType.GASOLINE,
+    vin: '1HGCM82633A004352',
+    licensePlate: 'ABC123',
+    purchaseDate: new Date('2025-01-01T00:00:00Z'),
+    mileage: 15000,
+    createdAt: new Date('2026-01-01T00:00:00Z'),
+    updatedAt: new Date('2026-01-02T00:00:00Z'),
+    ...overrides
+  })
+
+  const createMockVehicleEntity = () =>
+    new VehicleEntity(
+      new VehicleIdValueObject('123e4567-e89b-12d3-a456-426614174000'),
+      '123e4567-e89b-12d3-a456-426614174001',
+      'Toyota',
+      'Camry',
+      new YearValueObject(2020),
+      'V6',
+      FuelType.GASOLINE,
+      new VinValueObject('1HGCM82633A004352'),
+      'ABC123',
+      new Date('2025-01-01T00:00:00Z'),
+      new MileageValueObject(15000),
+      new Date('2026-01-01T00:00:00Z'),
+      new Date('2026-01-02T00:00:00Z')
+    )
+
+  beforeEach(() => {
+    mockPrismaService = {
+      vehicle: {
+        create: mock(() => {}) as unknown as Mock<PrismaProvider['vehicle']['create']>,
+        findUnique: mock(() => {}) as unknown as Mock<PrismaProvider['vehicle']['findUnique']>,
+        findMany: mock(() => {}) as unknown as Mock<PrismaProvider['vehicle']['findMany']>,
+        findFirst: mock(() => {}) as unknown as Mock<PrismaProvider['vehicle']['findFirst']>,
+        update: mock(() => {}) as unknown as Mock<PrismaProvider['vehicle']['update']>,
+        delete: mock(() => {}) as unknown as Mock<PrismaProvider['vehicle']['delete']>
+      }
+    }
+
+    repository = new PrismaVehicleRepository(mockPrismaService as unknown as PrismaProvider)
+  })
+
+  describe('create', () => {
+    it('should create vehicle and return domain entity', async () => {
+      const vehicleEntity = createMockVehicleEntity()
+      const prismaVehicle = createMockPrismaVehicle()
+
+      mockPrismaService.vehicle.create.mockResolvedValue(prismaVehicle)
+
+      const result = await repository.create(vehicleEntity)
+
+      expect(mockPrismaService.vehicle.create).toHaveBeenCalledWith({
+        data: VehicleInfrastructureMapper.toPrisma(vehicleEntity)
+      })
+      expect(result).toEqual(VehicleInfrastructureMapper.toDomain(prismaVehicle))
+    })
+
+    it('should throw VehicleAlreadyExistsException on unique constraint violation', async () => {
+      const prismaError = new Prisma.PrismaClientKnownRequestError('Unique constraint failed', {
+        code: 'P2002',
+        clientVersion: '7.0.0'
+      })
+
+      mockPrismaService.vehicle.create.mockRejectedValue(prismaError)
+
+      await expect(repository.create(createMockVehicleEntity())).rejects.toThrow(
+        VehicleAlreadyExistsException
+      )
+    })
+  })
+
+  describe('findById', () => {
+    it('should find vehicle by id and return domain entity', async () => {
+      const vehicleId = new VehicleIdValueObject('123e4567-e89b-12d3-a456-426614174000')
+      const prismaVehicle = createMockPrismaVehicle()
+
+      mockPrismaService.vehicle.findUnique.mockResolvedValue(prismaVehicle)
+
+      const result = await repository.findById(vehicleId)
+
+      expect(mockPrismaService.vehicle.findUnique).toHaveBeenCalledWith({
+        where: { id: vehicleId.value }
+      })
+      expect(result).toEqual(VehicleInfrastructureMapper.toDomain(prismaVehicle))
+    })
+
+    it('should return null when vehicle not found', async () => {
+      const vehicleId = new VehicleIdValueObject('123e4567-e89b-12d3-a456-426614174000')
+
+      mockPrismaService.vehicle.findUnique.mockResolvedValue(null)
+
+      const result = await repository.findById(vehicleId)
+
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('findByUserId', () => {
+    it('should find all vehicles for user', async () => {
+      const userId = '123e4567-e89b-12d3-a456-426614174001'
+      const prismaVehicles = [
+        createMockPrismaVehicle(),
+        createMockPrismaVehicle({ id: '123e4567-e89b-12d3-a456-426614174002' })
+      ]
+
+      mockPrismaService.vehicle.findMany.mockResolvedValue(prismaVehicles)
+
+      const result = await repository.findByUserId(userId)
+
+      expect(mockPrismaService.vehicle.findMany).toHaveBeenCalledWith({
+        where: { userId }
+      })
+      expect(result).toEqual(prismaVehicles.map(VehicleInfrastructureMapper.toDomain))
+    })
+
+    it('should return empty array when user has no vehicles', async () => {
+      const userId = '123e4567-e89b-12d3-a456-426614174001'
+
+      mockPrismaService.vehicle.findMany.mockResolvedValue([])
+
+      const result = await repository.findByUserId(userId)
+
+      expect(result).toEqual([])
+    })
+  })
+
+  describe('update', () => {
+    it('should update vehicle and return domain entity', async () => {
+      const vehicleEntity = createMockVehicleEntity()
+      const updatedPrismaVehicle = createMockPrismaVehicle({ make: 'Honda' })
+
+      mockPrismaService.vehicle.update.mockResolvedValue(updatedPrismaVehicle)
+
+      const result = await repository.update(vehicleEntity)
+
+      expect(mockPrismaService.vehicle.update).toHaveBeenCalledWith({
+        where: { id: vehicleEntity.id.value },
+        data: VehicleInfrastructureMapper.toPrisma(vehicleEntity)
+      })
+      expect(result).toEqual(VehicleInfrastructureMapper.toDomain(updatedPrismaVehicle))
+    })
+
+    it('should throw VehicleNotFoundException when vehicle does not exist', async () => {
+      const prismaError = new Prisma.PrismaClientKnownRequestError('Record not found', {
+        code: 'P2025',
+        clientVersion: '7.0.0'
+      })
+
+      mockPrismaService.vehicle.update.mockRejectedValue(prismaError)
+
+      await expect(repository.update(createMockVehicleEntity())).rejects.toThrow(
+        VehicleNotFoundException
+      )
+    })
+  })
+
+  describe('delete', () => {
+    it('should delete vehicle by id', async () => {
+      const vehicleId = new VehicleIdValueObject('123e4567-e89b-12d3-a456-426614174000')
+      const deletedVehicle = createMockPrismaVehicle({ id: vehicleId.value })
+
+      mockPrismaService.vehicle.delete.mockResolvedValue(deletedVehicle)
+
+      await repository.delete(vehicleId)
+
+      expect(mockPrismaService.vehicle.delete).toHaveBeenCalledWith({
+        where: { id: vehicleId.value }
+      })
+    })
+
+    it('should throw VehicleNotFoundException when vehicle does not exist', async () => {
+      const prismaError = new Prisma.PrismaClientKnownRequestError('Record not found', {
+        code: 'P2025',
+        clientVersion: '7.0.0'
+      })
+
+      mockPrismaService.vehicle.delete.mockRejectedValue(prismaError)
+
+      await expect(
+        repository.delete(new VehicleIdValueObject('123e4567-e89b-12d3-a456-426614174000'))
+      ).rejects.toThrow(VehicleNotFoundException)
+    })
+  })
+
+  describe('existsForUser', () => {
+    it('should return true when vehicle exists for user', async () => {
+      const vehicleId = new VehicleIdValueObject('123e4567-e89b-12d3-a456-426614174000')
+      const userId = '123e4567-e89b-12d3-a456-426614174001'
+      const foundVehicle = createMockPrismaVehicle({ id: vehicleId.value, userId })
+
+      mockPrismaService.vehicle.findFirst.mockResolvedValue(foundVehicle)
+
+      const result = await repository.existsForUser(vehicleId, userId)
+
+      expect(mockPrismaService.vehicle.findFirst).toHaveBeenCalledWith({
+        where: { id: vehicleId.value, userId }
+      })
+      expect(result).toBe(true)
+    })
+
+    it('should return false when vehicle does not exist for user', async () => {
+      const vehicleId = new VehicleIdValueObject('123e4567-e89b-12d3-a456-426614174000')
+      const userId = '123e4567-e89b-12d3-a456-426614174001'
+
+      mockPrismaService.vehicle.findFirst.mockResolvedValue(null)
+
+      const result = await repository.existsForUser(vehicleId, userId)
+
+      expect(mockPrismaService.vehicle.findFirst).toHaveBeenCalledWith({
+        where: { id: vehicleId.value, userId }
+      })
+      expect(result).toBe(false)
+    })
+  })
+})

--- a/apps/api/src/vehicles/infrastructure/repositories/PrismaVehicle.repository.ts
+++ b/apps/api/src/vehicles/infrastructure/repositories/PrismaVehicle.repository.ts
@@ -27,7 +27,7 @@ export class PrismaVehicleRepository implements IVehicleRepository {
     } catch (error) {
       if (error instanceof Prisma.PrismaClientKnownRequestError) {
         if (error.code === 'P2002') {
-          throw new VehicleAlreadyExistsException('A vehicle with the same VIN already exists.')
+          throw new VehicleAlreadyExistsException('This user already has a registered vehicle.')
         }
       }
 

--- a/apps/api/src/vehicles/infrastructure/repositories/PrismaVehicle.repository.ts
+++ b/apps/api/src/vehicles/infrastructure/repositories/PrismaVehicle.repository.ts
@@ -1,0 +1,96 @@
+import { Injectable } from '@nestjs/common'
+
+import { Prisma } from '@generated'
+
+import type { PrismaProvider } from '~/shared/infrastructure/database'
+import type { VehicleEntity } from '~/vehicles/domain/entities'
+import {
+  VehicleAlreadyExistsException,
+  VehicleNotFoundException
+} from '~/vehicles/domain/exceptions'
+import type { IVehicleRepository } from '~/vehicles/domain/repositories'
+import type { VehicleIdValueObject } from '~/vehicles/domain/value-objects'
+
+import { VehicleInfrastructureMapper } from '../mappers'
+
+@Injectable()
+export class PrismaVehicleRepository implements IVehicleRepository {
+  constructor(private readonly prisma: PrismaProvider) {}
+
+  async create(vehicle: VehicleEntity): Promise<VehicleEntity> {
+    try {
+      const prismaVehicle = await this.prisma.vehicle.create({
+        data: VehicleInfrastructureMapper.toPrisma(vehicle)
+      })
+
+      return VehicleInfrastructureMapper.toDomain(prismaVehicle)
+    } catch (error) {
+      if (error instanceof Prisma.PrismaClientKnownRequestError) {
+        if (error.code === 'P2002') {
+          throw new VehicleAlreadyExistsException('A vehicle with the same VIN already exists.')
+        }
+      }
+
+      throw error
+    }
+  }
+
+  async findById(vehicleId: VehicleIdValueObject): Promise<VehicleEntity | null> {
+    const prismaVehicle = await this.prisma.vehicle.findUnique({
+      where: { id: vehicleId.value }
+    })
+
+    return prismaVehicle ? VehicleInfrastructureMapper.toDomain(prismaVehicle) : null
+  }
+
+  async findByUserId(userId: string): Promise<VehicleEntity[]> {
+    const prismaVehicles = await this.prisma.vehicle.findMany({
+      where: { userId }
+    })
+
+    return prismaVehicles.map(VehicleInfrastructureMapper.toDomain)
+  }
+
+  async update(vehicle: VehicleEntity): Promise<VehicleEntity> {
+    try {
+      const prismaVehicle = await this.prisma.vehicle.update({
+        where: { id: vehicle.id.value },
+        data: VehicleInfrastructureMapper.toPrisma(vehicle)
+      })
+
+      return VehicleInfrastructureMapper.toDomain(prismaVehicle)
+    } catch (error) {
+      if (error instanceof Prisma.PrismaClientKnownRequestError) {
+        if (error.code === 'P2025') {
+          throw new VehicleNotFoundException(`Vehicle with ID ${vehicle.id.value} not found.`)
+        }
+      }
+
+      throw error
+    }
+  }
+
+  async delete(vehicleId: VehicleIdValueObject): Promise<void> {
+    try {
+      await this.prisma.vehicle.delete({
+        where: { id: vehicleId.value }
+      })
+    } catch (error) {
+      if (error instanceof Prisma.PrismaClientKnownRequestError) {
+        if (error.code === 'P2025') {
+          throw new VehicleNotFoundException(`Vehicle with ID ${vehicleId.value} not found.`)
+        }
+      }
+
+      throw error
+    }
+  }
+
+  async existsForUser(vehicleId: VehicleIdValueObject, userId: string): Promise<boolean> {
+    const vehicle = await this.prisma.vehicle.findFirst({
+      where: { id: vehicleId.value, userId }
+    })
+
+    return vehicle !== null
+  }
+}

--- a/apps/api/src/vehicles/infrastructure/repositories/index.ts
+++ b/apps/api/src/vehicles/infrastructure/repositories/index.ts
@@ -1,0 +1,1 @@
+export { PrismaVehicleRepository } from './PrismaVehicle.repository'

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -57,11 +57,11 @@
 
 ---
 
-## Phase 4: Infrastructure Layer
+## Phase 4: Infrastructure Layer ✅
 
-- [ ] PrismaVehicle.repository.ts + tests
-- [ ] Vehicle.mapper.ts (infrastructure) + tests
-- [ ] Vehicle.controller.ts + tests
+- [x] PrismaVehicle.repository.ts + tests
+- [x] Vehicle.mapper.ts (infrastructure) + tests
+- [x] Vehicle.controller.ts + tests
 
 ---
 


### PR DESCRIPTION
## Summary
- **Infrastructure mapper** (`VehicleInfra.mapper.ts`): Prisma ↔ Domain entity translation
- **Prisma repository** (`PrismaVehicle.repository.ts`): implements `IVehicleRepository` with all CRUD operations
- **REST controller** (`Vehicle.controller.ts`): 5 endpoints (POST, GET /me, PATCH, PATCH /mileage, DELETE)

## Files
- `VehicleInfra.mapper.ts` + spec: Prisma model ↔ domain entity mapping
- `PrismaVehicle.repository.ts` + spec: repository implementation with PrismaProvider
- `Vehicle.controller.ts` + spec: REST endpoints with session-based auth
- `PROGRESS.md`: updated Phase 4 checkboxes

## Test plan
- [x] All unit tests pass (`bun run test`)
- [x] Typecheck passes (`bun run typecheck`)
- [x] Lint passes (`bun run lint:check`)
- [x] Format passes (`bun run format:check`)