### PR TITLE
refactor(web): consolidate duplicated handleApiResponse helper

### DIFF
--- a/apps/web/src/features/auth/api/auth.service.ts
+++ b/apps/web/src/features/auth/api/auth.service.ts
@@ -1,20 +1,10 @@
-import { api } from '~/lib/apiRequest'
-import type { ApiResponse, User } from '~/types'
-
-/**
- * Helper function for API responses that return data
- */
-const handleApiResponseWithData = <T>(response: ApiResponse<T>): T => {
-  if (response.success && response.data) {
-    return response.data
-  }
-  throw new Error(response.message || 'API request failed')
-}
+import { api, handleApiResponse } from '~/lib'
+import type { User } from '~/types'
 
 /**
  * Get current authenticated user (SSR-only - use useAuth hook on client)
  */
 export const getCurrentUser = async (): Promise<User> => {
   const response = await api.get<User>('/users/me')
-  return handleApiResponseWithData(response)
+  return handleApiResponse(response)
 }

--- a/apps/web/src/features/profile/api/user.service.ts
+++ b/apps/web/src/features/profile/api/user.service.ts
@@ -1,18 +1,7 @@
-import { api } from '~/lib/apiRequest'
-import type { ApiResponse } from '~/types/api.types'
+import { api, handleApiResponse } from '~/lib'
 import type { User } from '~/types/user.types'
 
 import type { UpdateProfileSchema } from '../schemas/user.schema'
-
-/**
- * Helper function for consistent API response handling
- */
-const handleApiResponse = <T>(response: ApiResponse<T>): T => {
-  if (response.success && response.data) {
-    return response.data
-  }
-  throw new Error(response.message || 'API request failed')
-}
 
 /**
  * Update user profile

--- a/apps/web/src/features/vehicles/api/vehicle.service.ts
+++ b/apps/web/src/features/vehicles/api/vehicle.service.ts
@@ -1,16 +1,7 @@
-import { api } from '~/lib/apiRequest'
-import type { ApiResponse } from '~/types/api.types'
+import { api, handleApiResponse } from '~/lib'
 
 import type { CreateVehicleSchema, UpdateMileageSchema, UpdateVehicleSchema } from '../schemas'
 import type { Vehicle } from '../types'
-
-const handleApiResponse = <T>(response: ApiResponse<T>): T => {
-  if (!response.success || response.data == null) {
-    throw new Error(response.message || 'API request failed')
-  }
-
-  return response.data
-}
 
 export const getMyVehicle = async (): Promise<Vehicle | null> => {
   const response = await api.get<Vehicle | null>('/vehicles/me')

--- a/apps/web/src/lib/handleApiResponse.spec.ts
+++ b/apps/web/src/lib/handleApiResponse.spec.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'bun:test'
+
+import { handleApiResponse } from './handleApiResponse'
+
+describe('handleApiResponse', () => {
+  it('should return data when response is successful with data', () => {
+    const mockResponse = {
+      success: true,
+      data: { id: '123', name: 'Test Vehicle' }
+    }
+
+    const result = handleApiResponse(mockResponse)
+
+    expect(result).toEqual({ id: '123', name: 'Test Vehicle' })
+  })
+
+  it('should throw with response message when response fails', () => {
+    const mockResponse = {
+      success: false,
+      message: 'Unauthorized access'
+    }
+
+    expect(() => handleApiResponse(mockResponse)).toThrow('Unauthorized access')
+  })
+
+  it('should throw with default message when response fails without message', () => {
+    const mockResponse = {
+      success: false
+    }
+
+    expect(() => handleApiResponse(mockResponse)).toThrow('API request failed')
+  })
+
+  it('should throw when response is successful but has no data', () => {
+    const mockResponse = {
+      success: true,
+      data: null
+    }
+
+    expect(() => handleApiResponse(mockResponse)).toThrow('API request failed')
+  })
+})

--- a/apps/web/src/lib/handleApiResponse.ts
+++ b/apps/web/src/lib/handleApiResponse.ts
@@ -1,0 +1,9 @@
+import type { ApiResponse } from '~/types'
+
+export const handleApiResponse = <T>(response: ApiResponse<T>): T => {
+  if (!response.success || response.data == null) {
+    throw new Error(response.message || 'API request failed')
+  }
+
+  return response.data
+}

--- a/apps/web/src/lib/index.ts
+++ b/apps/web/src/lib/index.ts
@@ -1,0 +1,3 @@
+export { api } from './apiRequest'
+export { admin, authClient, signIn, signOut, signUp, useSession } from './authClient'
+export { handleApiResponse } from './handleApiResponse'


### PR DESCRIPTION
## Summary

- Extract shared `handleApiResponse` helper into `~/lib/`
- Add barrel export `~/lib/index.ts` for clean imports
- Remove 3 duplicated local helpers from service files

## Files changed

**New:**
- `handleApiResponse.ts`: generic helper to extract data or throw
- `handleApiResponse.spec.ts`: 4 tests (success, failure, default msg, null data)
- `index.ts`: barrel export for `~/lib`

**Updated:**
- `auth.service.ts`: use shared helper from `~/lib`
- `user.service.ts`: use shared helper from `~/lib`
- `vehicle.service.ts`: use shared helper from `~/lib`

## Test plan

- [x] All tests pass (373 frontend + 251 backend)
- [x] Typecheck passes
- [x] Lint passes
- [x] Format passes

Closes #9