### PR TITLE
refactor(profile): remove cross-feature import in ChangePasswordForm

### DIFF
--- a/apps/web/src/features/auth/index.ts
+++ b/apps/web/src/features/auth/index.ts
@@ -9,10 +9,6 @@ export { VerifyEmailContainer } from './components/VerifyEmailContainer'
 // Hooks
 export { useAuth } from './hooks/useAuth'
 
-// Schemas
-export { changePasswordSchema } from './schemas/auth.schema'
-export type { ChangePasswordSchema } from './schemas/auth.schema'
-
 // Types
 export { isValidAuthMode } from './types/auth.types'
 export type { AuthMode } from './types/auth.types'

--- a/apps/web/src/features/auth/schemas/auth.schema.spec.ts
+++ b/apps/web/src/features/auth/schemas/auth.schema.spec.ts
@@ -1,12 +1,6 @@
 import { describe, expect, it } from 'bun:test'
 
-import {
-  changePasswordSchema,
-  forgotPasswordSchema,
-  loginSchema,
-  resetPasswordSchema,
-  signupSchema
-} from './auth.schema'
+import { forgotPasswordSchema, loginSchema, resetPasswordSchema, signupSchema } from './auth.schema'
 
 describe('loginSchema', () => {
   it('should validate a valid login request', () => {
@@ -216,35 +210,6 @@ describe('resetPasswordSchema', () => {
     const result = resetPasswordSchema.safeParse({
       password: 'short',
       confirmPassword: 'short'
-    })
-    expect(result.success).toBe(false)
-  })
-})
-
-describe('changePasswordSchema', () => {
-  it('should validate valid change password request', () => {
-    const result = changePasswordSchema.safeParse({
-      currentPassword: 'oldpass123',
-      newPassword: 'newpass123',
-      confirmPassword: 'newpass123'
-    })
-    expect(result.success).toBe(true)
-  })
-
-  it('should reject when new passwords do not match', () => {
-    const result = changePasswordSchema.safeParse({
-      currentPassword: 'oldpass123',
-      newPassword: 'newpass123',
-      confirmPassword: 'different123'
-    })
-    expect(result.success).toBe(false)
-  })
-
-  it('should reject empty current password', () => {
-    const result = changePasswordSchema.safeParse({
-      currentPassword: '',
-      newPassword: 'newpass123',
-      confirmPassword: 'newpass123'
     })
     expect(result.success).toBe(false)
   })

--- a/apps/web/src/features/auth/schemas/auth.schema.ts
+++ b/apps/web/src/features/auth/schemas/auth.schema.ts
@@ -44,24 +44,9 @@ export const resetPasswordSchema = z
     path: ['confirmPassword']
   })
 
-export const changePasswordSchema = z
-  .object({
-    currentPassword: z.string().min(1, { message: 'Current password is required' }),
-    newPassword: z
-      .string()
-      .min(1, { message: 'New password is required' })
-      .min(8, { message: 'Password must be at least 8 characters' }),
-    confirmPassword: z.string().min(1, { message: 'Please confirm your password' })
-  })
-  .refine(data => data.newPassword === data.confirmPassword, {
-    message: 'Passwords do not match',
-    path: ['confirmPassword']
-  })
-
 // Types
 export type LoginSchema = z.infer<typeof loginSchema>
 export type SignupSchema = z.infer<typeof signupSchema>
 export type AuthSchema = LoginSchema | SignupSchema
 export type ForgotPasswordSchema = z.infer<typeof forgotPasswordSchema>
 export type ResetPasswordSchema = z.infer<typeof resetPasswordSchema>
-export type ChangePasswordSchema = z.infer<typeof changePasswordSchema>

--- a/apps/web/src/features/profile/components/ChangePasswordForm.tsx
+++ b/apps/web/src/features/profile/components/ChangePasswordForm.tsx
@@ -3,9 +3,10 @@ import { useState } from 'react'
 import { useForm } from 'react-hook-form'
 
 import { Button, FormWrapper, Input } from '~/components/ui'
-import type { ChangePasswordSchema } from '~/features/auth'
-import { changePasswordSchema } from '~/features/auth'
 import { authClient } from '~/lib/authClient'
+
+import type { ChangePasswordSchema } from '../schemas'
+import { changePasswordSchema } from '../schemas'
 
 export const ChangePasswordForm = () => {
   const [status, setStatus] = useState<'idle' | 'success' | 'error'>('idle')

--- a/apps/web/src/features/profile/schemas/changePassword.schema.spec.ts
+++ b/apps/web/src/features/profile/schemas/changePassword.schema.spec.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'bun:test'
+
+import { changePasswordSchema } from './changePassword.schema'
+
+describe('changePasswordSchema', () => {
+  it('should validate valid change password request', () => {
+    const result = changePasswordSchema.safeParse({
+      currentPassword: 'oldpass123',
+      newPassword: 'newpass123',
+      confirmPassword: 'newpass123'
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('should reject when new passwords do not match', () => {
+    const result = changePasswordSchema.safeParse({
+      currentPassword: 'oldpass123',
+      newPassword: 'newpass123',
+      confirmPassword: 'different123'
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('should reject empty current password', () => {
+    const result = changePasswordSchema.safeParse({
+      currentPassword: '',
+      newPassword: 'newpass123',
+      confirmPassword: 'newpass123'
+    })
+    expect(result.success).toBe(false)
+  })
+})

--- a/apps/web/src/features/profile/schemas/changePassword.schema.ts
+++ b/apps/web/src/features/profile/schemas/changePassword.schema.ts
@@ -1,0 +1,17 @@
+import { z } from 'zod'
+
+export const changePasswordSchema = z
+  .object({
+    currentPassword: z.string().min(1, { message: 'Current password is required' }),
+    newPassword: z
+      .string()
+      .min(1, { message: 'New password is required' })
+      .min(8, { message: 'Password must be at least 8 characters' }),
+    confirmPassword: z.string().min(1, { message: 'Please confirm your password' })
+  })
+  .refine(data => data.newPassword === data.confirmPassword, {
+    message: 'Passwords do not match',
+    path: ['confirmPassword']
+  })
+
+export type ChangePasswordSchema = z.infer<typeof changePasswordSchema>

--- a/apps/web/src/features/profile/schemas/index.ts
+++ b/apps/web/src/features/profile/schemas/index.ts
@@ -1,0 +1,2 @@
+export { changePasswordSchema, type ChangePasswordSchema } from './changePassword.schema'
+export { updateProfileSchema, type UpdateProfileSchema } from './user.schema'


### PR DESCRIPTION
## Summary

- Move `changePasswordSchema` from auth feature to profile feature
- Eliminate cross-feature import that violated feature encapsulation
- Add barrel export for profile schemas

## Files changed

**New (profile feature):**
- `changePassword.schema.ts`: schema moved from auth
- `changePassword.schema.spec.ts`: tests moved from auth
- `schemas/index.ts`: barrel export for profile schemas

**Updated:**
- `ChangePasswordForm.tsx`: import from own feature
- `auth.schema.ts`: remove changePassword schema and type
- `auth.schema.spec.ts`: remove changePassword tests
- `auth/index.ts`: remove changePassword exports

## Test plan

- [x] All tests pass (373 frontend + 251 backend)
- [x] Typecheck passes
- [x] Lint passes
- [x] Format passes
- [x] Zero cross-feature imports from profile to auth

Closes #7