### PR TITLE
feat(check-types): add application layer (DTOs, mapper, use cases, service)

### DIFF
--- a/apps/api/src/check-types/application/dtos/CreateCheckType.dto.spec.ts
+++ b/apps/api/src/check-types/application/dtos/CreateCheckType.dto.spec.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'bun:test'
+
+import { CreateCheckTypeDto } from './CreateCheckType.dto'
+
+describe('CreateCheckTypeDto', () => {
+  const createDto = (overrides: Partial<CreateCheckTypeDto> = {}): CreateCheckTypeDto =>
+    Object.assign(new CreateCheckTypeDto(), {
+      name: 'Oil Level Check',
+      description: 'Check the oil level and condition.',
+      intervalDays: 14,
+      ...overrides
+    })
+
+  it('should create instance with required properties', () => {
+    const dto = createDto()
+
+    expect(dto).toBeInstanceOf(CreateCheckTypeDto)
+    expect(dto.name).toBe('Oil Level Check')
+    expect(dto.intervalDays).toBe(14)
+  })
+
+  it('should create instance with all properties including description', () => {
+    const dto = createDto({ description: 'Check the oil level and condition.' })
+
+    expect(dto).toBeInstanceOf(CreateCheckTypeDto)
+    expect(dto.name).toBe('Oil Level Check')
+    expect(dto.description).toBe('Check the oil level and condition.')
+    expect(dto.intervalDays).toBe(14)
+  })
+
+  it('should have undefined description by default', () => {
+    const dto = createDto({ description: undefined })
+
+    expect(dto).toBeInstanceOf(CreateCheckTypeDto)
+    expect(dto.name).toBe('Oil Level Check')
+    expect(dto.description).toBeUndefined()
+    expect(dto.intervalDays).toBe(14)
+  })
+
+  it('should be serializable to JSON', () => {
+    const checkType = {
+      name: 'Tire Pressure Check',
+      description: 'Check the tire pressure and condition.',
+      intervalDays: 30
+    }
+    const dto = createDto(checkType)
+
+    const json = JSON.stringify(dto)
+    const parsed = JSON.parse(json)
+
+    expect(parsed.name).toBe(checkType.name)
+    expect(parsed.description).toBe(checkType.description)
+    expect(parsed.intervalDays).toBe(checkType.intervalDays)
+  })
+})

--- a/apps/api/src/check-types/application/dtos/CreateCheckType.dto.ts
+++ b/apps/api/src/check-types/application/dtos/CreateCheckType.dto.ts
@@ -1,0 +1,24 @@
+import { IsInt, IsNotEmpty, IsOptional, IsString, MaxLength, Min, MinLength } from 'class-validator'
+
+import { CHECK_TYPE_VALIDATION as checkTypeValidation } from '~/check-types/domain/validation'
+
+export class CreateCheckTypeDto {
+  @IsString()
+  @IsNotEmpty({ message: 'Name cannot be empty' })
+  @MinLength(checkTypeValidation.NAME.MIN_LENGTH, { message: checkTypeValidation.NAME.MESSAGE })
+  @MaxLength(checkTypeValidation.NAME.MAX_LENGTH, { message: checkTypeValidation.NAME.MESSAGE })
+  name!: string
+
+  @IsInt()
+  @Min(checkTypeValidation.INTERVAL_DAYS.MIN, {
+    message: checkTypeValidation.INTERVAL_DAYS.MESSAGE
+  })
+  intervalDays!: number
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(checkTypeValidation.DESCRIPTION.MAX_LENGTH, {
+    message: checkTypeValidation.DESCRIPTION.MESSAGE
+  })
+  description?: string
+}

--- a/apps/api/src/check-types/application/dtos/GetCheckType.dto.spec.ts
+++ b/apps/api/src/check-types/application/dtos/GetCheckType.dto.spec.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'bun:test'
+
+import { GetCheckTypeDto } from './GetCheckType.dto'
+
+describe('GetCheckTypeDto', () => {
+  const getDto = (overrides: Partial<GetCheckTypeDto> = {}): GetCheckTypeDto =>
+    Object.assign(new GetCheckTypeDto(), {
+      id: '123',
+      vehicleId: '456',
+      name: 'Oil Level Check',
+      description: 'Check the oil level and condition.',
+      intervalDays: 14,
+      createdAt: new Date('2026-01-01T00:00:00Z'),
+      updatedAt: new Date('2026-01-02T00:00:00Z'),
+      ...overrides
+    })
+
+  it('should create instance with all properties', () => {
+    const dto = getDto()
+
+    expect(dto).toBeInstanceOf(GetCheckTypeDto)
+    expect(dto.id).toBe('123')
+    expect(dto.vehicleId).toBe('456')
+    expect(dto.name).toBe('Oil Level Check')
+    expect(dto.description).toBe('Check the oil level and condition.')
+    expect(dto.intervalDays).toBe(14)
+    expect(dto.createdAt).toEqual(new Date('2026-01-01T00:00:00Z'))
+    expect(dto.updatedAt).toEqual(new Date('2026-01-02T00:00:00Z'))
+  })
+
+  it('should handle null description', () => {
+    const dto = getDto({ description: null })
+
+    expect(dto).toBeInstanceOf(GetCheckTypeDto)
+    expect(dto.description).toBeNull()
+  })
+
+  it('should be serializable to JSON', () => {
+    const dto = getDto()
+    const json = JSON.stringify(dto)
+    const parsed = JSON.parse(json)
+
+    expect(parsed.id).toBe(dto.id)
+    expect(parsed.vehicleId).toBe(dto.vehicleId)
+    expect(parsed.name).toBe(dto.name)
+    expect(parsed.description).toBe(dto.description)
+    expect(parsed.intervalDays).toBe(dto.intervalDays)
+    expect(new Date(parsed.createdAt)).toEqual(dto.createdAt)
+    expect(new Date(parsed.updatedAt)).toEqual(dto.updatedAt)
+  })
+})

--- a/apps/api/src/check-types/application/dtos/GetCheckType.dto.ts
+++ b/apps/api/src/check-types/application/dtos/GetCheckType.dto.ts
@@ -1,0 +1,9 @@
+export class GetCheckTypeDto {
+  id!: string
+  vehicleId!: string
+  name!: string
+  description!: string | null
+  intervalDays!: number
+  createdAt!: Date
+  updatedAt!: Date
+}

--- a/apps/api/src/check-types/application/dtos/UpdateCheckType.dto.spec.ts
+++ b/apps/api/src/check-types/application/dtos/UpdateCheckType.dto.spec.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'bun:test'
+
+import { UpdateCheckTypeDto } from './UpdateCheckType.dto'
+
+describe('UpdateCheckTypeDto', () => {
+  const updateDto = (overrides: Partial<UpdateCheckTypeDto> = {}): UpdateCheckTypeDto =>
+    Object.assign(new UpdateCheckTypeDto(), {
+      name: 'Oil Level Check',
+      description: 'Check the oil level and condition.',
+      intervalDays: 14,
+      ...overrides
+    })
+
+  it('should create empty instance with all fields undefined', () => {
+    const dto = updateDto({ name: undefined, description: undefined, intervalDays: undefined })
+
+    expect(dto).toBeInstanceOf(UpdateCheckTypeDto)
+    expect(dto.name).toBeUndefined()
+    expect(dto.description).toBeUndefined()
+    expect(dto.intervalDays).toBeUndefined()
+  })
+
+  it('should create instance with single property', () => {
+    const dto = updateDto({
+      name: 'Brake Pad Check',
+      description: undefined,
+      intervalDays: undefined
+    })
+
+    expect(dto).toBeInstanceOf(UpdateCheckTypeDto)
+    expect(dto.name).toBe('Brake Pad Check')
+    expect(dto.description).toBeUndefined()
+    expect(dto.intervalDays).toBeUndefined()
+  })
+
+  it('should create instance with all properties', () => {
+    const checkType = {
+      name: 'Brake Pad Check',
+      description: 'Check the brake pads condition.',
+      intervalDays: 30
+    }
+    const dto = updateDto(checkType)
+
+    expect(dto).toBeInstanceOf(UpdateCheckTypeDto)
+    expect(dto.name).toBe('Brake Pad Check')
+    expect(dto.description).toBe('Check the brake pads condition.')
+    expect(dto.intervalDays).toBe(30)
+  })
+
+  it('should accept null description to clear the field', () => {
+    const dto = updateDto({ description: null })
+
+    expect(dto).toBeInstanceOf(UpdateCheckTypeDto)
+    expect(dto.description).toBeNull()
+  })
+
+  it('should be serializable to JSON', () => {
+    const checkType = {
+      name: 'Brake Pad Check',
+      description: 'Check the brake pads condition.',
+      intervalDays: 30
+    }
+    const dto = updateDto(checkType)
+
+    const json = JSON.stringify(dto)
+    const parsed = JSON.parse(json)
+
+    expect(parsed.name).toBe(dto.name)
+    expect(parsed.description).toBe(dto.description)
+    expect(parsed.intervalDays).toBe(dto.intervalDays)
+  })
+})

--- a/apps/api/src/check-types/application/dtos/UpdateCheckType.dto.ts
+++ b/apps/api/src/check-types/application/dtos/UpdateCheckType.dto.ts
@@ -1,0 +1,18 @@
+import { OmitType, PartialType } from '@nestjs/mapped-types'
+import { IsOptional, IsString, MaxLength, ValidateIf } from 'class-validator'
+
+import { CHECK_TYPE_VALIDATION as checkTypeValidation } from '~/check-types/domain/validation'
+
+import { CreateCheckTypeDto } from './CreateCheckType.dto'
+
+export class UpdateCheckTypeDto extends PartialType(
+  OmitType(CreateCheckTypeDto, ['description'] as const)
+) {
+  @IsOptional()
+  @ValidateIf((_obj, value) => value !== null)
+  @IsString()
+  @MaxLength(checkTypeValidation.DESCRIPTION.MAX_LENGTH, {
+    message: checkTypeValidation.DESCRIPTION.MESSAGE
+  })
+  description?: string | null
+}

--- a/apps/api/src/check-types/application/dtos/index.ts
+++ b/apps/api/src/check-types/application/dtos/index.ts
@@ -1,0 +1,3 @@
+export { CreateCheckTypeDto } from './CreateCheckType.dto'
+export { GetCheckTypeDto } from './GetCheckType.dto'
+export { UpdateCheckTypeDto } from './UpdateCheckType.dto'

--- a/apps/api/src/check-types/application/mappers/CheckType.mapper.spec.ts
+++ b/apps/api/src/check-types/application/mappers/CheckType.mapper.spec.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'bun:test'
+
+import { CheckTypeEntity } from '~/check-types/domain/entities'
+import {
+  CheckTypeIdValueObject,
+  CheckTypeNameValueObject,
+  IntervalDaysValueObject
+} from '~/check-types/domain/value-objects'
+
+import { CheckTypeMapper } from './CheckType.mapper'
+
+describe('CheckTypeMapper', () => {
+  describe('toGetCheckTypeDto', () => {
+    it('should convert entity to DTO with all fields', () => {
+      const entity = new CheckTypeEntity(
+        new CheckTypeIdValueObject('123e4567-e89b-12d3-a456-426614174000'),
+        'vehicle-123',
+        new CheckTypeNameValueObject('Oil Level Check'),
+        'Check the oil level and condition.',
+        new IntervalDaysValueObject(14),
+        new Date('2026-01-01T00:00:00Z'),
+        new Date('2026-01-02T00:00:00Z')
+      )
+
+      const dto = CheckTypeMapper.toGetCheckTypeDto(entity)
+
+      expect(dto.id).toBe(entity.id.value)
+      expect(dto.vehicleId).toBe(entity.vehicleId)
+      expect(dto.name).toBe(entity.name.value)
+      expect(dto.description).toBe(entity.description)
+      expect(dto.intervalDays).toBe(entity.intervalDays.value)
+      expect(dto.createdAt).toBe(entity.createdAt)
+      expect(dto.updatedAt).toBe(entity.updatedAt)
+    })
+
+    it('should handle null description', () => {
+      const entity = new CheckTypeEntity(
+        new CheckTypeIdValueObject('123e4567-e89b-12d3-a456-426614174000'),
+        'vehicle-123',
+        new CheckTypeNameValueObject('Tire Pressure Check'),
+        null,
+        new IntervalDaysValueObject(30),
+        new Date('2026-01-01T00:00:00Z'),
+        new Date('2026-01-02T00:00:00Z')
+      )
+
+      const dto = CheckTypeMapper.toGetCheckTypeDto(entity)
+
+      expect(dto.id).toBe(entity.id.value)
+      expect(dto.vehicleId).toBe(entity.vehicleId)
+      expect(dto.name).toBe(entity.name.value)
+      expect(dto.description).toBeNull()
+      expect(dto.intervalDays).toBe(entity.intervalDays.value)
+      expect(dto.createdAt).toBe(entity.createdAt)
+      expect(dto.updatedAt).toBe(entity.updatedAt)
+    })
+  })
+})

--- a/apps/api/src/check-types/application/mappers/CheckType.mapper.ts
+++ b/apps/api/src/check-types/application/mappers/CheckType.mapper.ts
@@ -1,0 +1,19 @@
+import type { CheckTypeEntity } from '~/check-types/domain/entities'
+
+import { GetCheckTypeDto } from '../dtos'
+
+export class CheckTypeMapper {
+  static toGetCheckTypeDto(entity: CheckTypeEntity): GetCheckTypeDto {
+    const dto: GetCheckTypeDto = {
+      id: entity.id.value,
+      vehicleId: entity.vehicleId,
+      name: entity.name.value,
+      description: entity.description,
+      intervalDays: entity.intervalDays.value,
+      createdAt: entity.createdAt,
+      updatedAt: entity.updatedAt
+    }
+
+    return Object.assign(new GetCheckTypeDto(), dto)
+  }
+}

--- a/apps/api/src/check-types/application/mappers/index.ts
+++ b/apps/api/src/check-types/application/mappers/index.ts
@@ -1,0 +1,1 @@
+export { CheckTypeMapper } from './CheckType.mapper'

--- a/apps/api/src/check-types/application/services/CheckType.service.spec.ts
+++ b/apps/api/src/check-types/application/services/CheckType.service.spec.ts
@@ -1,0 +1,132 @@
+import { Test } from '@nestjs/testing'
+import type { Mock } from 'bun:test'
+import { beforeEach, describe, expect, it, mock } from 'bun:test'
+
+import {
+  CreateCheckTypeUseCase,
+  DeleteCheckTypeUseCase,
+  GetCheckTypeUseCase,
+  GetCheckTypesByVehicleUseCase,
+  UpdateCheckTypeUseCase
+} from '~/check-types/application/use-cases'
+
+import { CheckTypeService } from './CheckType.service'
+
+describe('CheckTypeService', () => {
+  let service: CheckTypeService
+  let mockCreateCheckTypeUseCase: {
+    execute: Mock<typeof CreateCheckTypeUseCase.prototype.execute>
+  }
+  let mockGetCheckTypesByVehicleUseCase: {
+    execute: Mock<typeof GetCheckTypesByVehicleUseCase.prototype.execute>
+  }
+  let mockGetCheckTypeUseCase: {
+    execute: Mock<typeof GetCheckTypeUseCase.prototype.execute>
+  }
+  let mockUpdateCheckTypeUseCase: {
+    execute: Mock<typeof UpdateCheckTypeUseCase.prototype.execute>
+  }
+  let mockDeleteCheckTypeUseCase: {
+    execute: Mock<typeof DeleteCheckTypeUseCase.prototype.execute>
+  }
+
+  beforeEach(async () => {
+    mockCreateCheckTypeUseCase = {
+      execute: mock(() => {}) as unknown as Mock<typeof CreateCheckTypeUseCase.prototype.execute>
+    }
+    mockGetCheckTypesByVehicleUseCase = {
+      execute: mock(() => {}) as unknown as Mock<
+        typeof GetCheckTypesByVehicleUseCase.prototype.execute
+      >
+    }
+    mockGetCheckTypeUseCase = {
+      execute: mock(() => {}) as unknown as Mock<typeof GetCheckTypeUseCase.prototype.execute>
+    }
+    mockUpdateCheckTypeUseCase = {
+      execute: mock(() => {}) as unknown as Mock<typeof UpdateCheckTypeUseCase.prototype.execute>
+    }
+    mockDeleteCheckTypeUseCase = {
+      execute: mock(() => {}) as unknown as Mock<typeof DeleteCheckTypeUseCase.prototype.execute>
+    }
+
+    const module = await Test.createTestingModule({
+      providers: [
+        CheckTypeService,
+        { provide: CreateCheckTypeUseCase, useValue: mockCreateCheckTypeUseCase },
+        { provide: GetCheckTypesByVehicleUseCase, useValue: mockGetCheckTypesByVehicleUseCase },
+        { provide: GetCheckTypeUseCase, useValue: mockGetCheckTypeUseCase },
+        { provide: UpdateCheckTypeUseCase, useValue: mockUpdateCheckTypeUseCase },
+        { provide: DeleteCheckTypeUseCase, useValue: mockDeleteCheckTypeUseCase }
+      ]
+    }).compile()
+
+    service = module.get<CheckTypeService>(CheckTypeService)
+  })
+
+  describe('createCheckType', () => {
+    it('should delegate to createCheckTypeUseCase with correct parameters', async () => {
+      const createCheckTypeDto = {
+        name: 'Oil Change',
+        description: 'Change the engine oil',
+        intervalDays: 60
+      }
+      const vehicleId = 'vehicle-123'
+
+      await service.createCheckType(createCheckTypeDto, vehicleId)
+
+      expect(mockCreateCheckTypeUseCase.execute).toHaveBeenCalledWith(createCheckTypeDto, vehicleId)
+    })
+  })
+
+  describe('getCheckTypesByVehicle', () => {
+    it('should delegate to getCheckTypesByVehicleUseCase with correct parameters', async () => {
+      const vehicleId = 'vehicle-123'
+
+      await service.getCheckTypesByVehicle(vehicleId)
+
+      expect(mockGetCheckTypesByVehicleUseCase.execute).toHaveBeenCalledWith(vehicleId)
+    })
+  })
+
+  describe('getCheckType', () => {
+    it('should delegate to getCheckTypeUseCase with correct parameters', async () => {
+      const id = 'check-type-123'
+      const vehicleId = 'vehicle-123'
+
+      await service.getCheckType(id, vehicleId)
+
+      expect(mockGetCheckTypeUseCase.execute).toHaveBeenCalledWith(id, vehicleId)
+    })
+  })
+
+  describe('updateCheckType', () => {
+    it('should delegate to updateCheckTypeUseCase with correct parameters', async () => {
+      const id = 'check-type-123'
+      const vehicleId = 'vehicle-123'
+      const updateCheckTypeDto = {
+        name: 'Oil Change',
+        description: 'Change the engine oil',
+        intervalDays: 60
+      }
+
+      await service.updateCheckType(id, vehicleId, updateCheckTypeDto)
+
+      expect(mockUpdateCheckTypeUseCase.execute).toHaveBeenCalledWith(
+        id,
+        vehicleId,
+        updateCheckTypeDto
+      )
+    })
+  })
+
+  describe('deleteCheckType', () => {
+    it('should delegate to deleteCheckTypeUseCase with correct parameters', async () => {
+      const id = 'check-type-123'
+      const vehicleId = 'vehicle-123'
+
+      await service.deleteCheckType(id, vehicleId)
+
+      expect(mockDeleteCheckTypeUseCase.execute).toHaveBeenCalledWith(id, vehicleId)
+    })
+  })
+})

--- a/apps/api/src/check-types/application/services/CheckType.service.ts
+++ b/apps/api/src/check-types/application/services/CheckType.service.ts
@@ -1,0 +1,49 @@
+import { Injectable } from '@nestjs/common'
+
+import type {
+  CreateCheckTypeDto,
+  GetCheckTypeDto,
+  UpdateCheckTypeDto
+} from '~/check-types/application/dtos'
+import {
+  CreateCheckTypeUseCase,
+  DeleteCheckTypeUseCase,
+  GetCheckTypeUseCase,
+  GetCheckTypesByVehicleUseCase,
+  UpdateCheckTypeUseCase
+} from '~/check-types/application/use-cases'
+
+@Injectable()
+export class CheckTypeService {
+  constructor(
+    private readonly createCheckTypeUseCase: CreateCheckTypeUseCase,
+    private readonly getCheckTypesByVehicleUseCase: GetCheckTypesByVehicleUseCase,
+    private readonly getCheckTypeUseCase: GetCheckTypeUseCase,
+    private readonly updateCheckTypeUseCase: UpdateCheckTypeUseCase,
+    private readonly deleteCheckTypeUseCase: DeleteCheckTypeUseCase
+  ) {}
+
+  async createCheckType(dto: CreateCheckTypeDto, vehicleId: string): Promise<GetCheckTypeDto> {
+    return this.createCheckTypeUseCase.execute(dto, vehicleId)
+  }
+
+  async getCheckTypesByVehicle(vehicleId: string): Promise<GetCheckTypeDto[]> {
+    return this.getCheckTypesByVehicleUseCase.execute(vehicleId)
+  }
+
+  async getCheckType(id: string, vehicleId: string): Promise<GetCheckTypeDto> {
+    return this.getCheckTypeUseCase.execute(id, vehicleId)
+  }
+
+  async updateCheckType(
+    id: string,
+    vehicleId: string,
+    dto: UpdateCheckTypeDto
+  ): Promise<GetCheckTypeDto> {
+    return this.updateCheckTypeUseCase.execute(id, vehicleId, dto)
+  }
+
+  async deleteCheckType(id: string, vehicleId: string): Promise<void> {
+    return this.deleteCheckTypeUseCase.execute(id, vehicleId)
+  }
+}

--- a/apps/api/src/check-types/application/services/index.ts
+++ b/apps/api/src/check-types/application/services/index.ts
@@ -1,0 +1,1 @@
+export { CheckTypeService } from './CheckType.service'

--- a/apps/api/src/check-types/application/use-cases/CreateCheckType.uc.spec.ts
+++ b/apps/api/src/check-types/application/use-cases/CreateCheckType.uc.spec.ts
@@ -68,7 +68,7 @@ describe('CreateCheckTypeUseCase', () => {
       mockCheckTypeRepository.existsByNameAndVehicle.mockReturnValueOnce(Promise.resolve(true))
 
       await expect(useCase.execute(dto, vehicleId)).rejects.toThrow(
-        `Check type with name "${dto.name}" already exists for this vehicle`
+        `Check type already exists: ${dto.name}`
       )
 
       expect(mockCheckTypeRepository.existsByNameAndVehicle).toHaveBeenCalledWith(

--- a/apps/api/src/check-types/application/use-cases/CreateCheckType.uc.spec.ts
+++ b/apps/api/src/check-types/application/use-cases/CreateCheckType.uc.spec.ts
@@ -1,0 +1,81 @@
+import type { Mock } from 'bun:test'
+import { beforeEach, describe, expect, it, mock } from 'bun:test'
+
+import type { ICheckTypeRepository } from '~/check-types/domain/repositories'
+
+import type { CreateCheckTypeDto } from '../dtos'
+
+import { CreateCheckTypeUseCase } from './CreateCheckType.uc'
+
+describe('CreateCheckTypeUseCase', () => {
+  let useCase: CreateCheckTypeUseCase
+  let mockCheckTypeRepository: {
+    create: Mock<ICheckTypeRepository['create']>
+    findById: Mock<ICheckTypeRepository['findById']>
+    findByVehicleId: Mock<ICheckTypeRepository['findByVehicleId']>
+    update: Mock<ICheckTypeRepository['update']>
+    delete: Mock<ICheckTypeRepository['delete']>
+    existsByNameAndVehicle: Mock<ICheckTypeRepository['existsByNameAndVehicle']>
+  }
+
+  beforeEach(() => {
+    mockCheckTypeRepository = {
+      create: mock(() => {}) as unknown as Mock<ICheckTypeRepository['create']>,
+      findById: mock(() => {}) as unknown as Mock<ICheckTypeRepository['findById']>,
+      findByVehicleId: mock(() => {}) as unknown as Mock<ICheckTypeRepository['findByVehicleId']>,
+      update: mock(() => {}) as unknown as Mock<ICheckTypeRepository['update']>,
+      delete: mock(() => {}) as unknown as Mock<ICheckTypeRepository['delete']>,
+      existsByNameAndVehicle: mock(() => {}) as unknown as Mock<
+        ICheckTypeRepository['existsByNameAndVehicle']
+      >
+    }
+    useCase = new CreateCheckTypeUseCase(mockCheckTypeRepository as unknown as ICheckTypeRepository)
+  })
+
+  describe('execute', () => {
+    it('should create a check type when name is unique for vehicle', async () => {
+      const vehicleId = 'vehicle-123'
+      const dto: CreateCheckTypeDto = {
+        name: 'Oil Change',
+        description: 'Change engine oil',
+        intervalDays: 180
+      }
+
+      mockCheckTypeRepository.existsByNameAndVehicle.mockReturnValueOnce(Promise.resolve(false))
+      mockCheckTypeRepository.create.mockImplementationOnce(async entity => entity)
+
+      const result = await useCase.execute(dto, vehicleId)
+
+      expect(mockCheckTypeRepository.existsByNameAndVehicle).toHaveBeenCalledWith(
+        dto.name,
+        vehicleId
+      )
+      expect(mockCheckTypeRepository.create).toHaveBeenCalled()
+      expect(result).toHaveProperty('id')
+      expect(result.name).toBe(dto.name)
+      expect(result.description).toBe('Change engine oil')
+      expect(result.intervalDays).toBe(dto.intervalDays)
+    })
+
+    it('should throw CheckTypeAlreadyExistsException when name already exists for vehicle', async () => {
+      const vehicleId = 'vehicle-123'
+      const dto: CreateCheckTypeDto = {
+        name: 'Oil Change',
+        description: 'Change engine oil',
+        intervalDays: 180
+      }
+
+      mockCheckTypeRepository.existsByNameAndVehicle.mockReturnValueOnce(Promise.resolve(true))
+
+      await expect(useCase.execute(dto, vehicleId)).rejects.toThrow(
+        `Check type with name "${dto.name}" already exists for this vehicle`
+      )
+
+      expect(mockCheckTypeRepository.existsByNameAndVehicle).toHaveBeenCalledWith(
+        dto.name,
+        vehicleId
+      )
+      expect(mockCheckTypeRepository.create).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/apps/api/src/check-types/application/use-cases/CreateCheckType.uc.ts
+++ b/apps/api/src/check-types/application/use-cases/CreateCheckType.uc.ts
@@ -1,0 +1,44 @@
+import { Injectable } from '@nestjs/common'
+
+import type { CreateCheckTypeDto, GetCheckTypeDto } from '~/check-types/application/dtos'
+import { CheckTypeMapper } from '~/check-types/application/mappers'
+import { CheckTypeEntity } from '~/check-types/domain/entities'
+import { CheckTypeAlreadyExistsException } from '~/check-types/domain/exceptions'
+import type { ICheckTypeRepository } from '~/check-types/domain/repositories'
+import {
+  CheckTypeIdValueObject,
+  CheckTypeNameValueObject,
+  IntervalDaysValueObject
+} from '~/check-types/domain/value-objects'
+
+@Injectable()
+export class CreateCheckTypeUseCase {
+  constructor(private readonly checkTypeRepository: ICheckTypeRepository) {}
+
+  async execute(dto: CreateCheckTypeDto, vehicleId: string): Promise<GetCheckTypeDto> {
+    const existingCheckType = await this.checkTypeRepository.existsByNameAndVehicle(
+      dto.name,
+      vehicleId
+    )
+
+    if (existingCheckType) {
+      throw new CheckTypeAlreadyExistsException(
+        `Check type with name "${dto.name}" already exists for this vehicle`
+      )
+    }
+
+    const entity = new CheckTypeEntity(
+      CheckTypeIdValueObject.generate(),
+      vehicleId,
+      new CheckTypeNameValueObject(dto.name),
+      dto.description ?? null,
+      new IntervalDaysValueObject(dto.intervalDays),
+      new Date(),
+      new Date()
+    )
+
+    const createdEntity = await this.checkTypeRepository.create(entity)
+
+    return CheckTypeMapper.toGetCheckTypeDto(createdEntity)
+  }
+}

--- a/apps/api/src/check-types/application/use-cases/CreateCheckType.uc.ts
+++ b/apps/api/src/check-types/application/use-cases/CreateCheckType.uc.ts
@@ -22,9 +22,7 @@ export class CreateCheckTypeUseCase {
     )
 
     if (existingCheckType) {
-      throw new CheckTypeAlreadyExistsException(
-        `Check type with name "${dto.name}" already exists for this vehicle`
-      )
+      throw new CheckTypeAlreadyExistsException(dto.name)
     }
 
     const entity = new CheckTypeEntity(

--- a/apps/api/src/check-types/application/use-cases/DeleteCheckType.uc.spec.ts
+++ b/apps/api/src/check-types/application/use-cases/DeleteCheckType.uc.spec.ts
@@ -1,0 +1,89 @@
+import type { Mock } from 'bun:test'
+import { beforeEach, describe, expect, it, mock } from 'bun:test'
+
+import { CheckTypeEntity } from '~/check-types/domain/entities'
+import type { ICheckTypeRepository } from '~/check-types/domain/repositories'
+import {
+  CheckTypeIdValueObject,
+  CheckTypeNameValueObject,
+  IntervalDaysValueObject
+} from '~/check-types/domain/value-objects'
+
+import { DeleteCheckTypeUseCase } from './DeleteCheckType.uc'
+
+const makeCheckTypeEntity = (overrides?: { vehicleId?: string }) => {
+  const vehicleId = overrides?.vehicleId ?? 'vehicle-123'
+  return new CheckTypeEntity(
+    CheckTypeIdValueObject.generate(),
+    vehicleId,
+    new CheckTypeNameValueObject('Oil Level'),
+    'Check the oil level',
+    new IntervalDaysValueObject(30),
+    new Date(),
+    new Date()
+  )
+}
+
+describe('DeleteCheckTypeUseCase', () => {
+  let useCase: DeleteCheckTypeUseCase
+  let mockCheckTypeRepository: {
+    create: Mock<ICheckTypeRepository['create']>
+    findById: Mock<ICheckTypeRepository['findById']>
+    findByVehicleId: Mock<ICheckTypeRepository['findByVehicleId']>
+    update: Mock<ICheckTypeRepository['update']>
+    delete: Mock<ICheckTypeRepository['delete']>
+    existsByNameAndVehicle: Mock<ICheckTypeRepository['existsByNameAndVehicle']>
+  }
+
+  beforeEach(() => {
+    mockCheckTypeRepository = {
+      create: mock(() => {}) as unknown as Mock<ICheckTypeRepository['create']>,
+      findById: mock(() => {}) as unknown as Mock<ICheckTypeRepository['findById']>,
+      findByVehicleId: mock(() => {}) as unknown as Mock<ICheckTypeRepository['findByVehicleId']>,
+      update: mock(() => {}) as unknown as Mock<ICheckTypeRepository['update']>,
+      delete: mock(() => {}) as unknown as Mock<ICheckTypeRepository['delete']>,
+      existsByNameAndVehicle: mock(() => {}) as unknown as Mock<
+        ICheckTypeRepository['existsByNameAndVehicle']
+      >
+    }
+    useCase = new DeleteCheckTypeUseCase(mockCheckTypeRepository as unknown as ICheckTypeRepository)
+  })
+
+  describe('execute', () => {
+    it('should delete the check type when found and belongs to the vehicle', async () => {
+      const entity = makeCheckTypeEntity()
+
+      mockCheckTypeRepository.findById.mockResolvedValueOnce(entity)
+      mockCheckTypeRepository.delete.mockResolvedValueOnce()
+
+      await useCase.execute(entity.id.value, entity.vehicleId)
+
+      expect(mockCheckTypeRepository.findById).toHaveBeenCalledWith(
+        expect.objectContaining({ value: entity.id.value })
+      )
+      expect(mockCheckTypeRepository.delete).toHaveBeenCalledWith(
+        expect.objectContaining({ value: entity.id.value })
+      )
+    })
+
+    it('should throw CheckTypeNotFoundException when check type does not exist', async () => {
+      const validUUID = CheckTypeIdValueObject.generate().value
+
+      mockCheckTypeRepository.findById.mockResolvedValueOnce(null)
+      await expect(useCase.execute(validUUID, 'vehicle-123')).rejects.toThrow(
+        'Check type not found'
+      )
+      expect(mockCheckTypeRepository.delete).not.toHaveBeenCalled()
+    })
+
+    it('should throw CheckTypeNotFoundException when check type belongs to a different vehicle', async () => {
+      const entity = makeCheckTypeEntity({ vehicleId: 'vehicle-A' })
+
+      mockCheckTypeRepository.findById.mockResolvedValueOnce(entity)
+      await expect(useCase.execute(entity.id.value, 'vehicle-B')).rejects.toThrow(
+        'Check type not found'
+      )
+      expect(mockCheckTypeRepository.delete).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/apps/api/src/check-types/application/use-cases/DeleteCheckType.uc.ts
+++ b/apps/api/src/check-types/application/use-cases/DeleteCheckType.uc.ts
@@ -1,0 +1,22 @@
+import { Injectable } from '@nestjs/common'
+
+import { CheckTypeNotFoundException } from '~/check-types/domain/exceptions'
+import type { ICheckTypeRepository } from '~/check-types/domain/repositories'
+import { CheckTypeIdValueObject } from '~/check-types/domain/value-objects'
+
+@Injectable()
+export class DeleteCheckTypeUseCase {
+  constructor(private readonly checkTypeRepository: ICheckTypeRepository) {}
+
+  async execute(id: string, vehicleId: string): Promise<void> {
+    const checkTypeId = new CheckTypeIdValueObject(id)
+
+    const checkType = await this.checkTypeRepository.findById(checkTypeId)
+
+    if (!checkType || checkType.vehicleId !== vehicleId) {
+      throw new CheckTypeNotFoundException(id)
+    }
+
+    await this.checkTypeRepository.delete(checkTypeId)
+  }
+}

--- a/apps/api/src/check-types/application/use-cases/GetCheckType.uc.spec.ts
+++ b/apps/api/src/check-types/application/use-cases/GetCheckType.uc.spec.ts
@@ -1,0 +1,92 @@
+import type { Mock } from 'bun:test'
+import { beforeEach, describe, expect, it, mock } from 'bun:test'
+
+import { CheckTypeEntity } from '~/check-types/domain/entities'
+import type { ICheckTypeRepository } from '~/check-types/domain/repositories'
+import {
+  CheckTypeIdValueObject,
+  CheckTypeNameValueObject,
+  IntervalDaysValueObject
+} from '~/check-types/domain/value-objects'
+
+import { GetCheckTypeUseCase } from './GetCheckType.uc'
+
+describe('GetCheckTypeUseCase', () => {
+  let useCase: GetCheckTypeUseCase
+  let mockCheckTypeRepository: {
+    create: Mock<ICheckTypeRepository['create']>
+    findById: Mock<ICheckTypeRepository['findById']>
+    findByVehicleId: Mock<ICheckTypeRepository['findByVehicleId']>
+    update: Mock<ICheckTypeRepository['update']>
+    delete: Mock<ICheckTypeRepository['delete']>
+    existsByNameAndVehicle: Mock<ICheckTypeRepository['existsByNameAndVehicle']>
+  }
+
+  beforeEach(() => {
+    mockCheckTypeRepository = {
+      create: mock(() => {}) as unknown as Mock<ICheckTypeRepository['create']>,
+      findById: mock(() => {}) as unknown as Mock<ICheckTypeRepository['findById']>,
+      findByVehicleId: mock(() => {}) as unknown as Mock<ICheckTypeRepository['findByVehicleId']>,
+      update: mock(() => {}) as unknown as Mock<ICheckTypeRepository['update']>,
+      delete: mock(() => {}) as unknown as Mock<ICheckTypeRepository['delete']>,
+      existsByNameAndVehicle: mock(() => {}) as unknown as Mock<
+        ICheckTypeRepository['existsByNameAndVehicle']
+      >
+    }
+    useCase = new GetCheckTypeUseCase(mockCheckTypeRepository as unknown as ICheckTypeRepository)
+  })
+
+  describe('execute', () => {
+    it('should return the check type when found and belongs to the vehicle', async () => {
+      const vehicleId = 'vehicle-123'
+      const checkTypeEntity = new CheckTypeEntity(
+        CheckTypeIdValueObject.generate(),
+        vehicleId,
+        new CheckTypeNameValueObject('Brake Inspection'),
+        'Inspect brake pads and rotors',
+        new IntervalDaysValueObject(365),
+        new Date(),
+        new Date()
+      )
+
+      mockCheckTypeRepository.findById.mockResolvedValue(checkTypeEntity)
+
+      const result = await useCase.execute(checkTypeEntity.id.value, vehicleId)
+
+      expect(result).toHaveProperty('id', checkTypeEntity.id.value)
+      expect(result).toHaveProperty('name', checkTypeEntity.name.value)
+      expect(result).toHaveProperty('description', checkTypeEntity.description)
+      expect(result).toHaveProperty('intervalDays', checkTypeEntity.intervalDays.value)
+      expect(mockCheckTypeRepository.findById).toHaveBeenCalledWith(
+        expect.objectContaining({ value: checkTypeEntity.id.value })
+      )
+    })
+
+    it('should throw CheckTypeNotFoundException when check type does not exist', async () => {
+      const validUUID = CheckTypeIdValueObject.generate().value
+      mockCheckTypeRepository.findById.mockResolvedValue(null)
+
+      await expect(useCase.execute(validUUID, 'vehicle-123')).rejects.toThrow(
+        `Check type not found: ${validUUID}`
+      )
+    })
+
+    it('should throw CheckTypeNotFoundException when check type belongs to a different vehicle', async () => {
+      const checkTypeEntity = new CheckTypeEntity(
+        CheckTypeIdValueObject.generate(),
+        'vehicle-A',
+        new CheckTypeNameValueObject('Tire Rotation'),
+        'Rotate tires for even wear',
+        new IntervalDaysValueObject(180),
+        new Date(),
+        new Date()
+      )
+
+      mockCheckTypeRepository.findById.mockResolvedValue(checkTypeEntity)
+
+      await expect(useCase.execute(checkTypeEntity.id.value, 'vehicle-B')).rejects.toThrow(
+        `Check type not found: ${checkTypeEntity.id.value}`
+      )
+    })
+  })
+})

--- a/apps/api/src/check-types/application/use-cases/GetCheckType.uc.ts
+++ b/apps/api/src/check-types/application/use-cases/GetCheckType.uc.ts
@@ -1,0 +1,23 @@
+import { Injectable } from '@nestjs/common'
+
+import type { GetCheckTypeDto } from '~/check-types/application/dtos'
+import { CheckTypeMapper } from '~/check-types/application/mappers'
+import { CheckTypeNotFoundException } from '~/check-types/domain/exceptions'
+import type { ICheckTypeRepository } from '~/check-types/domain/repositories'
+import { CheckTypeIdValueObject } from '~/check-types/domain/value-objects'
+
+@Injectable()
+export class GetCheckTypeUseCase {
+  constructor(private readonly checkTypeRepository: ICheckTypeRepository) {}
+
+  async execute(id: string, vehicleId: string): Promise<GetCheckTypeDto> {
+    const checkTypeIdVO = new CheckTypeIdValueObject(id)
+    const checkType = await this.checkTypeRepository.findById(checkTypeIdVO)
+
+    if (!checkType || checkType.vehicleId !== vehicleId) {
+      throw new CheckTypeNotFoundException(id)
+    }
+
+    return CheckTypeMapper.toGetCheckTypeDto(checkType)
+  }
+}

--- a/apps/api/src/check-types/application/use-cases/GetCheckTypesByVehicle.uc.spec.ts
+++ b/apps/api/src/check-types/application/use-cases/GetCheckTypesByVehicle.uc.spec.ts
@@ -1,0 +1,101 @@
+import type { Mock } from 'bun:test'
+import { beforeEach, describe, expect, it, mock } from 'bun:test'
+
+import { CheckTypeEntity } from '~/check-types/domain/entities'
+import type { ICheckTypeRepository } from '~/check-types/domain/repositories'
+import {
+  CheckTypeIdValueObject,
+  CheckTypeNameValueObject,
+  IntervalDaysValueObject
+} from '~/check-types/domain/value-objects'
+
+import { GetCheckTypesByVehicleUseCase } from './GetCheckTypesByVehicle.uc'
+
+describe('GetCheckTypesByVehicleUseCase', () => {
+  let useCase: GetCheckTypesByVehicleUseCase
+  let mockCheckTypeRepository: {
+    create: Mock<ICheckTypeRepository['create']>
+    findById: Mock<ICheckTypeRepository['findById']>
+    findByVehicleId: Mock<ICheckTypeRepository['findByVehicleId']>
+    update: Mock<ICheckTypeRepository['update']>
+    delete: Mock<ICheckTypeRepository['delete']>
+    existsByNameAndVehicle: Mock<ICheckTypeRepository['existsByNameAndVehicle']>
+  }
+
+  beforeEach(() => {
+    mockCheckTypeRepository = {
+      create: mock(() => {}) as unknown as Mock<ICheckTypeRepository['create']>,
+      findById: mock(() => {}) as unknown as Mock<ICheckTypeRepository['findById']>,
+      findByVehicleId: mock(() => {}) as unknown as Mock<ICheckTypeRepository['findByVehicleId']>,
+      update: mock(() => {}) as unknown as Mock<ICheckTypeRepository['update']>,
+      delete: mock(() => {}) as unknown as Mock<ICheckTypeRepository['delete']>,
+      existsByNameAndVehicle: mock(() => {}) as unknown as Mock<
+        ICheckTypeRepository['existsByNameAndVehicle']
+      >
+    }
+    useCase = new GetCheckTypesByVehicleUseCase(
+      mockCheckTypeRepository as unknown as ICheckTypeRepository
+    )
+  })
+
+  describe('execute', () => {
+    it('should return all check types for a vehicle', async () => {
+      const vehicleId = 'vehicle-123'
+      const checkTypes = [
+        new CheckTypeEntity(
+          new CheckTypeIdValueObject(CheckTypeIdValueObject.generate().value),
+          vehicleId,
+          new CheckTypeNameValueObject('Oil Change'),
+          'Oil change every 6 months',
+          new IntervalDaysValueObject(180),
+          new Date(),
+          new Date()
+        ),
+        new CheckTypeEntity(
+          new CheckTypeIdValueObject(CheckTypeIdValueObject.generate().value),
+          vehicleId,
+          new CheckTypeNameValueObject('Tire Rotation'),
+          null,
+          new IntervalDaysValueObject(365),
+          new Date(),
+          new Date()
+        )
+      ]
+      mockCheckTypeRepository.findByVehicleId.mockResolvedValue(checkTypes)
+
+      const result = await useCase.execute(vehicleId)
+
+      expect(result).toEqual([
+        {
+          id: checkTypes[0].id.value,
+          vehicleId: checkTypes[0].vehicleId,
+          name: checkTypes[0].name.value,
+          description: checkTypes[0].description,
+          intervalDays: checkTypes[0].intervalDays.value,
+          createdAt: checkTypes[0].createdAt,
+          updatedAt: checkTypes[0].updatedAt
+        },
+        {
+          id: checkTypes[1].id.value,
+          vehicleId: checkTypes[1].vehicleId,
+          name: checkTypes[1].name.value,
+          description: checkTypes[1].description,
+          intervalDays: checkTypes[1].intervalDays.value,
+          createdAt: checkTypes[1].createdAt,
+          updatedAt: checkTypes[1].updatedAt
+        }
+      ])
+      expect(mockCheckTypeRepository.findByVehicleId).toHaveBeenCalledWith(vehicleId)
+    })
+
+    it('should return empty array when vehicle has no check types', async () => {
+      const vehicleId = 'vehicle-123'
+      mockCheckTypeRepository.findByVehicleId.mockResolvedValue([])
+
+      const result = await useCase.execute(vehicleId)
+
+      expect(result).toEqual([])
+      expect(mockCheckTypeRepository.findByVehicleId).toHaveBeenCalledWith(vehicleId)
+    })
+  })
+})

--- a/apps/api/src/check-types/application/use-cases/GetCheckTypesByVehicle.uc.ts
+++ b/apps/api/src/check-types/application/use-cases/GetCheckTypesByVehicle.uc.ts
@@ -1,0 +1,16 @@
+import { Injectable } from '@nestjs/common'
+
+import type { GetCheckTypeDto } from '~/check-types/application/dtos'
+import { CheckTypeMapper } from '~/check-types/application/mappers'
+import type { ICheckTypeRepository } from '~/check-types/domain/repositories'
+
+@Injectable()
+export class GetCheckTypesByVehicleUseCase {
+  constructor(private readonly checkTypeRepository: ICheckTypeRepository) {}
+
+  async execute(vehicleId: string): Promise<GetCheckTypeDto[]> {
+    const checkTypes = await this.checkTypeRepository.findByVehicleId(vehicleId)
+
+    return checkTypes.map(CheckTypeMapper.toGetCheckTypeDto)
+  }
+}

--- a/apps/api/src/check-types/application/use-cases/UpdateCheckType.uc.spec.ts
+++ b/apps/api/src/check-types/application/use-cases/UpdateCheckType.uc.spec.ts
@@ -1,0 +1,150 @@
+import type { Mock } from 'bun:test'
+import { beforeEach, describe, expect, it, mock } from 'bun:test'
+
+import { CheckTypeEntity } from '~/check-types/domain/entities'
+import type { ICheckTypeRepository } from '~/check-types/domain/repositories'
+import {
+  CheckTypeIdValueObject,
+  CheckTypeNameValueObject,
+  IntervalDaysValueObject
+} from '~/check-types/domain/value-objects'
+
+import type { UpdateCheckTypeDto } from '../dtos'
+
+import { UpdateCheckTypeUseCase } from './UpdateCheckType.uc'
+
+const makeCheckTypeEntity = (overrides?: { vehicleId?: string; name?: string }) => {
+  const vehicleId = overrides?.vehicleId ?? 'vehicle-123'
+  const name = overrides?.name ?? 'Oil Level'
+  return new CheckTypeEntity(
+    CheckTypeIdValueObject.generate(),
+    vehicleId,
+    new CheckTypeNameValueObject(name),
+    'Check the oil level',
+    new IntervalDaysValueObject(30),
+    new Date(),
+    new Date()
+  )
+}
+
+describe('UpdateCheckTypeUseCase', () => {
+  let useCase: UpdateCheckTypeUseCase
+  let mockCheckTypeRepository: {
+    create: Mock<ICheckTypeRepository['create']>
+    findById: Mock<ICheckTypeRepository['findById']>
+    findByVehicleId: Mock<ICheckTypeRepository['findByVehicleId']>
+    update: Mock<ICheckTypeRepository['update']>
+    delete: Mock<ICheckTypeRepository['delete']>
+    existsByNameAndVehicle: Mock<ICheckTypeRepository['existsByNameAndVehicle']>
+  }
+
+  beforeEach(() => {
+    mockCheckTypeRepository = {
+      create: mock(() => {}) as unknown as Mock<ICheckTypeRepository['create']>,
+      findById: mock(() => {}) as unknown as Mock<ICheckTypeRepository['findById']>,
+      findByVehicleId: mock(() => {}) as unknown as Mock<ICheckTypeRepository['findByVehicleId']>,
+      update: mock(() => {}) as unknown as Mock<ICheckTypeRepository['update']>,
+      delete: mock(() => {}) as unknown as Mock<ICheckTypeRepository['delete']>,
+      existsByNameAndVehicle: mock(() => {}) as unknown as Mock<
+        ICheckTypeRepository['existsByNameAndVehicle']
+      >
+    }
+    useCase = new UpdateCheckTypeUseCase(mockCheckTypeRepository as unknown as ICheckTypeRepository)
+  })
+
+  describe('execute', () => {
+    it('should update the check type name when provided', async () => {
+      const entity = makeCheckTypeEntity()
+
+      mockCheckTypeRepository.findById.mockResolvedValueOnce(entity)
+      mockCheckTypeRepository.existsByNameAndVehicle.mockResolvedValueOnce(false)
+      mockCheckTypeRepository.update.mockResolvedValueOnce(entity)
+
+      const dto: UpdateCheckTypeDto = { name: 'New Name Here' }
+      const result = await useCase.execute(entity.id.value, entity.vehicleId, dto)
+
+      expect(mockCheckTypeRepository.existsByNameAndVehicle).toHaveBeenCalledWith(
+        'New Name Here',
+        entity.vehicleId
+      )
+      expect(mockCheckTypeRepository.update).toHaveBeenCalled()
+      expect(result.name).toBe('New Name Here')
+    })
+
+    it('should update intervalDays without checking name uniqueness', async () => {
+      const entity = makeCheckTypeEntity()
+
+      mockCheckTypeRepository.findById.mockResolvedValueOnce(entity)
+      mockCheckTypeRepository.update.mockResolvedValueOnce(entity)
+
+      const dto: UpdateCheckTypeDto = { intervalDays: 60 }
+      const result = await useCase.execute(entity.id.value, entity.vehicleId, dto)
+
+      expect(mockCheckTypeRepository.existsByNameAndVehicle).not.toHaveBeenCalled()
+      expect(mockCheckTypeRepository.update).toHaveBeenCalled()
+      expect(result.intervalDays).toBe(60)
+    })
+
+    it('should clear description when explicitly set to null', async () => {
+      const entity = makeCheckTypeEntity()
+
+      mockCheckTypeRepository.findById.mockResolvedValueOnce(entity)
+      mockCheckTypeRepository.update.mockResolvedValueOnce(entity)
+
+      const dto: UpdateCheckTypeDto = { description: null }
+      const result = await useCase.execute(entity.id.value, entity.vehicleId, dto)
+
+      expect(mockCheckTypeRepository.update).toHaveBeenCalled()
+      expect(result.description).toBeNull()
+    })
+
+    it('should throw CheckTypeNotFoundException when check type does not exist', async () => {
+      const validUUID = CheckTypeIdValueObject.generate().value
+
+      mockCheckTypeRepository.findById.mockResolvedValueOnce(null)
+
+      const dto: UpdateCheckTypeDto = { name: 'New Name' }
+      await expect(useCase.execute(validUUID, 'vehicle-id', dto)).rejects.toThrow(
+        `Check type not found: ${validUUID}`
+      )
+    })
+
+    it('should throw CheckTypeNotFoundException when check type belongs to a different vehicle', async () => {
+      const entity = makeCheckTypeEntity({ vehicleId: 'vehicle-A' })
+
+      mockCheckTypeRepository.findById.mockResolvedValueOnce(entity)
+
+      const dto: UpdateCheckTypeDto = { name: 'New Name' }
+      await expect(useCase.execute(entity.id.value, 'vehicle-B', dto)).rejects.toThrow(
+        `Check type not found: ${entity.id.value}`
+      )
+    })
+
+    it('should throw CheckTypeAlreadyExistsException when new name already exists for vehicle', async () => {
+      const entity = makeCheckTypeEntity()
+
+      mockCheckTypeRepository.findById.mockResolvedValueOnce(entity)
+      mockCheckTypeRepository.existsByNameAndVehicle.mockResolvedValueOnce(true)
+
+      const dto: UpdateCheckTypeDto = { name: 'Existing Name' }
+      await expect(useCase.execute(entity.id.value, entity.vehicleId, dto)).rejects.toThrow(
+        `Check type already exists: ${dto.name}`
+      )
+      expect(mockCheckTypeRepository.update).not.toHaveBeenCalled()
+    })
+
+    it('should skip name uniqueness check when name has not changed', async () => {
+      const entity = makeCheckTypeEntity({ name: 'Oil Level' })
+
+      mockCheckTypeRepository.findById.mockResolvedValueOnce(entity)
+      mockCheckTypeRepository.update.mockResolvedValueOnce(entity)
+
+      const dto: UpdateCheckTypeDto = { name: 'Oil Level' }
+      const result = await useCase.execute(entity.id.value, entity.vehicleId, dto)
+
+      expect(mockCheckTypeRepository.existsByNameAndVehicle).not.toHaveBeenCalled()
+      expect(mockCheckTypeRepository.update).toHaveBeenCalled()
+      expect(result.name).toBe('Oil Level')
+    })
+  })
+})

--- a/apps/api/src/check-types/application/use-cases/UpdateCheckType.uc.ts
+++ b/apps/api/src/check-types/application/use-cases/UpdateCheckType.uc.ts
@@ -1,0 +1,47 @@
+import { Injectable } from '@nestjs/common'
+
+import type { GetCheckTypeDto, UpdateCheckTypeDto } from '~/check-types/application/dtos'
+import { CheckTypeMapper } from '~/check-types/application/mappers'
+import {
+  CheckTypeAlreadyExistsException,
+  CheckTypeNotFoundException
+} from '~/check-types/domain/exceptions'
+import type { ICheckTypeRepository } from '~/check-types/domain/repositories'
+import {
+  CheckTypeIdValueObject,
+  CheckTypeNameValueObject,
+  IntervalDaysValueObject
+} from '~/check-types/domain/value-objects'
+
+@Injectable()
+export class UpdateCheckTypeUseCase {
+  constructor(private readonly checkTypeRepository: ICheckTypeRepository) {}
+
+  async execute(id: string, vehicleId: string, dto: UpdateCheckTypeDto): Promise<GetCheckTypeDto> {
+    const checkTypeId = new CheckTypeIdValueObject(id)
+    const checkTypeEntity = await this.checkTypeRepository.findById(checkTypeId)
+
+    if (!checkTypeEntity || checkTypeEntity.vehicleId !== vehicleId) {
+      throw new CheckTypeNotFoundException(id)
+    }
+
+    if (dto.name !== undefined && dto.name !== checkTypeEntity.name.value) {
+      const nameExists = await this.checkTypeRepository.existsByNameAndVehicle(dto.name, vehicleId)
+
+      if (nameExists) {
+        throw new CheckTypeAlreadyExistsException(dto.name)
+      }
+    }
+
+    const nameVO = dto.name !== undefined ? new CheckTypeNameValueObject(dto.name) : undefined
+
+    const intervalDaysVO =
+      dto.intervalDays !== undefined ? new IntervalDaysValueObject(dto.intervalDays) : undefined
+
+    checkTypeEntity.updateDetails(nameVO, dto.description, intervalDaysVO)
+
+    const updatedEntity = await this.checkTypeRepository.update(checkTypeEntity)
+
+    return CheckTypeMapper.toGetCheckTypeDto(updatedEntity)
+  }
+}

--- a/apps/api/src/check-types/application/use-cases/index.ts
+++ b/apps/api/src/check-types/application/use-cases/index.ts
@@ -1,0 +1,5 @@
+export { CreateCheckTypeUseCase } from './CreateCheckType.uc'
+export { DeleteCheckTypeUseCase } from './DeleteCheckType.uc'
+export { GetCheckTypeUseCase } from './GetCheckType.uc'
+export { GetCheckTypesByVehicleUseCase } from './GetCheckTypesByVehicle.uc'
+export { UpdateCheckTypeUseCase } from './UpdateCheckType.uc'

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -12,7 +12,7 @@
 
 ---
 
-## Phase 2: Domain Layer
+## Phase 2: Domain Layer ✅
 
 ### Value Objects
 
@@ -38,25 +38,25 @@
 
 ### DTOs
 
-- [ ] CreateCheckType.dto.ts + tests
-- [ ] UpdateCheckType.dto.ts + tests
-- [ ] GetCheckType.dto.ts + tests
+- [x] CreateCheckType.dto.ts + tests
+- [x] UpdateCheckType.dto.ts + tests
+- [x] GetCheckType.dto.ts + tests
 
 ### Mapper
 
-- [ ] CheckType.mapper.ts + tests
+- [x] CheckType.mapper.ts + tests
 
 ### Use Cases
 
-- [ ] CreateCheckType.uc.ts + tests
-- [ ] GetCheckTypesByVehicle.uc.ts + tests
-- [ ] GetCheckType.uc.ts + tests
-- [ ] UpdateCheckType.uc.ts + tests
-- [ ] DeleteCheckType.uc.ts + tests
+- [x] CreateCheckType.uc.ts + tests
+- [x] GetCheckTypesByVehicle.uc.ts + tests
+- [x] GetCheckType.uc.ts + tests
+- [x] UpdateCheckType.uc.ts + tests
+- [x] DeleteCheckType.uc.ts + tests
 
 ### Service
 
-- [ ] CheckType.service.ts + tests
+- [x] CheckType.service.ts + tests
 
 ---
 


### PR DESCRIPTION
## Summary

- **DTOs**: `CreateCheckType`, `UpdateCheckType` (with nullable description for PATCH semantics), `GetCheckType` — all with class-validator decorators and tests
- **Mapper**: `CheckTypeMapper` converts domain entities to DTOs
- **Use Cases**: Full CRUD — Create (with name uniqueness), GetByVehicle, Get (with ownership guard), Update (partial, with name uniqueness skip for same name), Delete (with ownership guard)
- **Service**: Thin facade delegating to all 5 use cases, wired via NestJS DI

## Key design decisions

- `UpdateCheckTypeDto` uses `OmitType` + re-declaration to support `description?: string | null` (PATCH semantics: `undefined` = don't touch, `null` = clear)
- All use cases that accept an `id` also require `vehicleId` and guard against cross-vehicle access (returns same `CheckTypeNotFoundException` to avoid information leakage)
- Name uniqueness check in Update is skipped when the name hasn't changed, avoiding false duplicate errors

## Test coverage

- 25 new tests across 13 files (67 total for check-types feature)
- All automated checks pass: tests, typecheck, lint, format

## Test plan

- [x] `bun run test` — 323 passing
- [x] `bun run typecheck` — clean
- [x] `bun run lint:check` — clean
- [x] `bun run format:check` — clean