### PR TITLE
feat(check-types): add frontend data layer (service, store, hook)

### DIFF
--- a/apps/web/src/features/check-types/api/checkType.service.spec.ts
+++ b/apps/web/src/features/check-types/api/checkType.service.spec.ts
@@ -97,6 +97,18 @@ describe('checkType.service', () => {
       expect(result).toEqual(checkTypeData)
     })
 
+    it('should return null when data is null', async () => {
+      getSpy.mockResolvedValueOnce({
+        success: true,
+        data: null
+      })
+
+      const result = await getCheckType('v1', 'ct1')
+
+      expect(getSpy).toHaveBeenCalledWith('/vehicles/v1/check-types/ct1')
+      expect(result).toBeNull()
+    })
+
     it('should throw on API failure', async () => {
       getSpy.mockResolvedValueOnce({
         success: false,

--- a/apps/web/src/features/check-types/api/checkType.service.spec.ts
+++ b/apps/web/src/features/check-types/api/checkType.service.spec.ts
@@ -1,0 +1,212 @@
+import type { Mock } from 'bun:test'
+import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test'
+
+import { api } from '~/lib/apiRequest'
+
+import type { CreateCheckTypeSchema, UpdateCheckTypeSchema } from '../schemas'
+import type { CheckType } from '../types'
+
+import {
+  createCheckType,
+  deleteCheckType,
+  getCheckType,
+  getCheckTypes,
+  updateCheckType
+} from './checkType.service'
+
+const mockCheckType: CheckType = {
+  id: 'ct1',
+  vehicleId: 'v1',
+  name: 'Oil Level Check',
+  description: null,
+  intervalDays: 7,
+  createdAt: '2026-01-01',
+  updatedAt: '2026-01-01'
+}
+
+describe('checkType.service', () => {
+  let getSpy: Mock<typeof api.get>
+  let postSpy: Mock<typeof api.post>
+  let patchSpy: Mock<typeof api.patch>
+  let deleteSpy: Mock<typeof api.delete>
+
+  beforeEach(() => {
+    getSpy = spyOn(api, 'get')
+    postSpy = spyOn(api, 'post')
+    patchSpy = spyOn(api, 'patch')
+    deleteSpy = spyOn(api, 'delete')
+  })
+
+  afterEach(() => {
+    getSpy.mockRestore()
+    postSpy.mockRestore()
+    patchSpy.mockRestore()
+    deleteSpy.mockRestore()
+  })
+
+  describe('getCheckTypes', () => {
+    it('should return check types for a vehicle', async () => {
+      const checkTypesData: CheckType[] = [mockCheckType]
+
+      getSpy.mockResolvedValueOnce({
+        success: true,
+        data: checkTypesData
+      })
+
+      const result = await getCheckTypes('v1')
+
+      expect(getSpy).toHaveBeenCalledWith('/vehicles/v1/check-types')
+      expect(result).toEqual(checkTypesData)
+    })
+
+    it('should return empty array when no check types exist', async () => {
+      getSpy.mockResolvedValueOnce({
+        success: true,
+        data: []
+      })
+
+      const result = await getCheckTypes('v1')
+
+      expect(getSpy).toHaveBeenCalledWith('/vehicles/v1/check-types')
+      expect(result).toEqual([])
+    })
+
+    it('should throw on API failure', async () => {
+      getSpy.mockResolvedValueOnce({
+        success: false,
+        message: 'API error'
+      })
+
+      await expect(getCheckTypes('v1')).rejects.toThrow('API error')
+      expect(api.get).toHaveBeenCalledWith('/vehicles/v1/check-types')
+    })
+  })
+
+  describe('getCheckType', () => {
+    it('should return a single check type', async () => {
+      const checkTypeData: CheckType = mockCheckType
+
+      getSpy.mockResolvedValueOnce({
+        success: true,
+        data: checkTypeData
+      })
+
+      const result = await getCheckType('v1', 'ct1')
+
+      expect(getSpy).toHaveBeenCalledWith('/vehicles/v1/check-types/ct1')
+      expect(result).toEqual(checkTypeData)
+    })
+
+    it('should throw on API failure', async () => {
+      getSpy.mockResolvedValueOnce({
+        success: false,
+        message: 'API error'
+      })
+
+      await expect(getCheckType('v1', 'ct1')).rejects.toThrow('API error')
+      expect(api.get).toHaveBeenCalledWith('/vehicles/v1/check-types/ct1')
+    })
+  })
+
+  describe('createCheckType', () => {
+    it('should call api.post with correct endpoint and data', async () => {
+      const createData: CreateCheckTypeSchema = {
+        name: 'Tire Pressure Check',
+        intervalDays: 14
+      }
+      const createdCheckType: CheckType = {
+        id: 'ct2',
+        vehicleId: 'v1',
+        name: createData.name,
+        description: null,
+        intervalDays: createData.intervalDays,
+        createdAt: '2026-01-02',
+        updatedAt: '2026-01-02'
+      }
+
+      postSpy.mockResolvedValueOnce({
+        success: true,
+        data: createdCheckType
+      })
+
+      const result = await createCheckType('v1', createData)
+
+      expect(postSpy).toHaveBeenCalledWith('/vehicles/v1/check-types', createData)
+      expect(result).toEqual(createdCheckType)
+    })
+
+    it('should throw on failed creation', async () => {
+      const createData: CreateCheckTypeSchema = {
+        name: 'Tire Pressure Check',
+        intervalDays: 14
+      }
+
+      postSpy.mockResolvedValueOnce({
+        success: false,
+        message: 'Creation failed'
+      })
+
+      await expect(createCheckType('v1', createData)).rejects.toThrow('Creation failed')
+      expect(postSpy).toHaveBeenCalledWith('/vehicles/v1/check-types', createData)
+    })
+  })
+
+  describe('updateCheckType', () => {
+    it('should call api.patch with correct endpoint and data', async () => {
+      const id = 'ct1'
+      const updateData: UpdateCheckTypeSchema = { name: 'Updated Name', intervalDays: 30 }
+      const updatedCheckType: CheckType = {
+        ...mockCheckType,
+        ...updateData
+      }
+
+      patchSpy.mockResolvedValueOnce({
+        success: true,
+        data: updatedCheckType
+      })
+
+      const result = await updateCheckType('v1', id, updateData)
+
+      expect(patchSpy).toHaveBeenCalledWith('/vehicles/v1/check-types/ct1', updateData)
+      expect(result).toEqual(updatedCheckType)
+    })
+
+    it('should throw on failed update', async () => {
+      const id = 'ct1'
+      const updateData: UpdateCheckTypeSchema = { name: 'Updated Name', intervalDays: 30 }
+
+      patchSpy.mockResolvedValueOnce({
+        success: false,
+        message: 'Update failed'
+      })
+
+      await expect(updateCheckType('v1', id, updateData)).rejects.toThrow('Update failed')
+      expect(patchSpy).toHaveBeenCalledWith('/vehicles/v1/check-types/ct1', updateData)
+    })
+  })
+
+  describe('deleteCheckType', () => {
+    it('should call api.delete with correct endpoint', async () => {
+      const id = 'ct1'
+
+      deleteSpy.mockResolvedValue({
+        success: true
+      })
+
+      await expect(deleteCheckType('v1', id)).resolves.toBeUndefined()
+      expect(api.delete).toHaveBeenCalledWith('/vehicles/v1/check-types/ct1')
+    })
+
+    it('should throw on failed deletion', async () => {
+      const id = 'ct1'
+
+      deleteSpy.mockResolvedValueOnce({
+        success: false,
+        message: 'Deletion failed'
+      })
+
+      await expect(deleteCheckType('v1', id)).rejects.toThrow('Deletion failed')
+      expect(deleteSpy).toHaveBeenCalledWith('/vehicles/v1/check-types/ct1')
+    })
+  })
+})

--- a/apps/web/src/features/check-types/api/checkType.service.ts
+++ b/apps/web/src/features/check-types/api/checkType.service.ts
@@ -1,0 +1,54 @@
+import { api, handleApiResponse } from '~/lib'
+
+import type { CreateCheckTypeSchema, UpdateCheckTypeSchema } from '../schemas'
+import type { CheckType } from '../types'
+
+const getBaseUrl = (vehicleId: string) => `/vehicles/${vehicleId}/check-types`
+
+export const getCheckTypes = async (vehicleId: string): Promise<CheckType[]> => {
+  const url = getBaseUrl(vehicleId)
+  const response = await api.get<CheckType[]>(url)
+
+  return handleApiResponse(response)
+}
+
+export const getCheckType = async (vehicleId: string, id: string): Promise<CheckType | null> => {
+  const url = `${getBaseUrl(vehicleId)}/${id}`
+  const response = await api.get<CheckType | null>(url)
+
+  if (!response.success) {
+    throw new Error(response.message || 'API request failed')
+  }
+
+  return response.data ?? null
+}
+
+export const createCheckType = async (
+  vehicleId: string,
+  data: CreateCheckTypeSchema
+): Promise<CheckType> => {
+  const url = getBaseUrl(vehicleId)
+  const response = await api.post<CheckType>(url, data)
+
+  return handleApiResponse(response)
+}
+
+export const updateCheckType = async (
+  vehicleId: string,
+  id: string,
+  data: UpdateCheckTypeSchema
+): Promise<CheckType> => {
+  const url = `${getBaseUrl(vehicleId)}/${id}`
+  const response = await api.patch<CheckType>(url, data)
+
+  return handleApiResponse(response)
+}
+
+export const deleteCheckType = async (vehicleId: string, id: string): Promise<void> => {
+  const url = `${getBaseUrl(vehicleId)}/${id}`
+  const response = await api.delete<void>(url)
+
+  if (!response.success) {
+    throw new Error(response.message || 'API request failed')
+  }
+}

--- a/apps/web/src/features/check-types/api/index.ts
+++ b/apps/web/src/features/check-types/api/index.ts
@@ -1,0 +1,7 @@
+export {
+  createCheckType,
+  deleteCheckType,
+  getCheckType,
+  getCheckTypes,
+  updateCheckType
+} from './checkType.service'

--- a/apps/web/src/features/check-types/hooks/index.ts
+++ b/apps/web/src/features/check-types/hooks/index.ts
@@ -1,0 +1,2 @@
+export { useCheckTypes } from './useCheckTypes'
+export type { UseCheckTypesReturn } from './useCheckTypes'

--- a/apps/web/src/features/check-types/hooks/useCheckTypes.spec.ts
+++ b/apps/web/src/features/check-types/hooks/useCheckTypes.spec.ts
@@ -1,0 +1,145 @@
+import { beforeEach, describe, expect, it, spyOn } from 'bun:test'
+
+import { cleanup, renderHook } from '~/test-utils'
+
+import { $checkTypes, $error, $isLoading, checkTypeActions } from '../store'
+import type { CheckType } from '../types'
+
+import { useCheckTypes } from './useCheckTypes'
+
+const mockCheckType: CheckType = {
+  id: 'ct1',
+  vehicleId: 'v1',
+  name: "Niveau d'huile",
+  description: null,
+  intervalDays: 7,
+  createdAt: '2024-01-01',
+  updatedAt: '2024-01-01'
+}
+
+describe('useCheckTypes', () => {
+  beforeEach(() => {
+    cleanup()
+    document.body.innerHTML = ''
+
+    $checkTypes.set([])
+    $isLoading.set(false)
+    $error.set(null)
+  })
+
+  describe('reactive state', () => {
+    it('should return checkTypes from store', () => {
+      $checkTypes.set([mockCheckType])
+
+      const { result } = renderHook(() => useCheckTypes())
+
+      expect(result.current.checkTypes).toEqual([mockCheckType])
+    })
+
+    it('should return empty array when store is empty', () => {
+      $checkTypes.set([])
+
+      const { result } = renderHook(() => useCheckTypes())
+
+      expect(result.current.checkTypes).toEqual([])
+    })
+
+    it('should return isLoading from store', () => {
+      $isLoading.set(true)
+
+      const { result } = renderHook(() => useCheckTypes())
+
+      expect(result.current.isLoading).toBe(true)
+    })
+
+    it('should return error from store', () => {
+      $error.set('Error message')
+
+      const { result } = renderHook(() => useCheckTypes())
+
+      expect(result.current.error).toBe('Error message')
+    })
+
+    it('should return hasCheckTypes as true when check types exist', () => {
+      $checkTypes.set([mockCheckType])
+
+      const { result } = renderHook(() => useCheckTypes())
+
+      expect(result.current.hasCheckTypes).toBe(true)
+    })
+
+    it('should return hasCheckTypes as false when no check types', () => {
+      $checkTypes.set([])
+
+      const { result } = renderHook(() => useCheckTypes())
+
+      expect(result.current.hasCheckTypes).toBe(false)
+    })
+
+    it('should return checkTypeCount from store', () => {
+      $checkTypes.set([mockCheckType, { ...mockCheckType, id: 'ct2' }])
+
+      const { result } = renderHook(() => useCheckTypes())
+
+      expect(result.current.checkTypeCount).toBe(2)
+    })
+  })
+
+  describe('actions', () => {
+    it('should call checkTypeActions.fetchByVehicle with vehicleId', async () => {
+      const spy = spyOn(checkTypeActions, 'fetchByVehicle').mockResolvedValue(undefined)
+
+      const { result } = renderHook(() => useCheckTypes())
+      await result.current.fetchByVehicle('v1')
+
+      expect(spy).toHaveBeenCalledWith('v1')
+      spy.mockRestore()
+    })
+
+    it('should call checkTypeActions.create with vehicleId and data', async () => {
+      const data = {
+        name: 'Vérification des freins',
+        description: "Vérifier l'état des freins",
+        intervalDays: 30
+      }
+      const spy = spyOn(checkTypeActions, 'create').mockResolvedValue(mockCheckType)
+
+      const { result } = renderHook(() => useCheckTypes())
+      await result.current.create('v1', data)
+
+      expect(spy).toHaveBeenCalledWith('v1', data)
+      spy.mockRestore()
+    })
+
+    it('should call checkTypeActions.update with vehicleId, id and data', async () => {
+      const data = { name: 'Vérification des freins - mise à jour' }
+      const spy = spyOn(checkTypeActions, 'update').mockResolvedValue({ ...mockCheckType, ...data })
+
+      const { result } = renderHook(() => useCheckTypes())
+      await result.current.update('v1', 'ct1', data)
+
+      expect(spy).toHaveBeenCalledWith('v1', 'ct1', data)
+      spy.mockRestore()
+    })
+
+    it('should call checkTypeActions.remove with vehicleId and id', async () => {
+      const spy = spyOn(checkTypeActions, 'remove').mockResolvedValue(undefined)
+
+      const { result } = renderHook(() => useCheckTypes())
+      await result.current.remove('v1', 'ct1')
+
+      expect(spy).toHaveBeenCalledWith('v1', 'ct1')
+      spy.mockRestore()
+    })
+
+    it('should call checkTypeActions.clearError', () => {
+      const spy = spyOn(checkTypeActions, 'clearError')
+
+      const { result } = renderHook(() => useCheckTypes())
+      result.current.clearError()
+
+      expect(spy).toHaveBeenCalled()
+      spy.mockRestore()
+    })
+  })
+})

--- a/apps/web/src/features/check-types/hooks/useCheckTypes.ts
+++ b/apps/web/src/features/check-types/hooks/useCheckTypes.ts
@@ -1,0 +1,45 @@
+import { useStore } from '@nanostores/react'
+import { useCallback } from 'react'
+
+import type { CreateCheckTypeSchema, UpdateCheckTypeSchema } from '../schemas'
+import {
+  $checkTypeCount,
+  $checkTypes,
+  $error,
+  $hasCheckTypes,
+  $isLoading,
+  checkTypeActions
+} from '../store'
+import type { CheckType } from '../types'
+
+export interface UseCheckTypesReturn {
+  checkTypes: CheckType[]
+  isLoading: boolean
+  error: string | null
+  hasCheckTypes: boolean
+  checkTypeCount: number
+  fetchByVehicle: (vehicleId: string) => Promise<void>
+  create: (vehicleId: string, data: CreateCheckTypeSchema) => Promise<CheckType>
+  update: (vehicleId: string, id: string, data: UpdateCheckTypeSchema) => Promise<CheckType>
+  remove: (vehicleId: string, id: string) => Promise<void>
+  clearError: () => void
+}
+
+export const useCheckTypes = (): UseCheckTypesReturn => {
+  const fetchByVehicle = useCallback(async (vehicleId: string) => {
+    await checkTypeActions.fetchByVehicle(vehicleId)
+  }, [])
+
+  return {
+    checkTypes: useStore($checkTypes),
+    isLoading: useStore($isLoading),
+    error: useStore($error),
+    hasCheckTypes: useStore($hasCheckTypes),
+    checkTypeCount: useStore($checkTypeCount),
+    fetchByVehicle,
+    create: async (vehicleId, data) => await checkTypeActions.create(vehicleId, data),
+    update: async (vehicleId, id, data) => await checkTypeActions.update(vehicleId, id, data),
+    remove: async (vehicleId, id) => await checkTypeActions.remove(vehicleId, id),
+    clearError: () => checkTypeActions.clearError()
+  }
+}

--- a/apps/web/src/features/check-types/store/checkType.store.spec.ts
+++ b/apps/web/src/features/check-types/store/checkType.store.spec.ts
@@ -1,0 +1,260 @@
+import type { Mock } from 'bun:test'
+import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test'
+
+import { api } from '~/lib/apiRequest'
+import { cleanup } from '~/test-utils'
+
+import type { CheckType } from '../types'
+
+import {
+  $checkTypeCount,
+  $checkTypes,
+  $error,
+  $hasCheckTypes,
+  $isLoading,
+  checkTypeActions
+} from './checkType.store'
+
+const mockCheckType: CheckType = {
+  id: 'ct1',
+  vehicleId: 'v1',
+  name: 'Oil Level Check',
+  description: null,
+  intervalDays: 7,
+  createdAt: '2026-01-01',
+  updatedAt: '2026-01-01'
+}
+
+const mockCheckType2: CheckType = {
+  id: 'ct2',
+  vehicleId: 'v1',
+  name: 'Tire Pressure Check',
+  description: null,
+  intervalDays: 14,
+  createdAt: '2026-01-02',
+  updatedAt: '2026-01-02'
+}
+
+let getSpy: Mock<typeof api.get>
+let postSpy: Mock<typeof api.post>
+let patchSpy: Mock<typeof api.patch>
+let deleteSpy: Mock<typeof api.delete>
+
+describe('CheckType Store', () => {
+  beforeEach(() => {
+    cleanup()
+    document.body.innerHTML = ''
+
+    getSpy = spyOn(api, 'get')
+    postSpy = spyOn(api, 'post')
+    patchSpy = spyOn(api, 'patch')
+    deleteSpy = spyOn(api, 'delete')
+
+    // Reset store state
+    $checkTypes.set([])
+    $isLoading.set(false)
+    $error.set(null)
+  })
+
+  afterEach(() => {
+    getSpy.mockRestore()
+    postSpy.mockRestore()
+    patchSpy.mockRestore()
+    deleteSpy.mockRestore()
+  })
+
+  describe('State Atoms', () => {
+    it('should initialize $checkTypes with empty array', () => {
+      expect($checkTypes.get()).toEqual([])
+    })
+
+    it('should initialize $isLoading with false', () => {
+      expect($isLoading.get()).toBe(false)
+    })
+
+    it('should initialize $error with null', () => {
+      expect($error.get()).toBeNull()
+    })
+  })
+
+  describe('Computed Values', () => {
+    it('should return false for $hasCheckTypes when list is empty', () => {
+      expect($hasCheckTypes.get()).toBe(false)
+    })
+
+    it('should return true for $hasCheckTypes when list has items', () => {
+      $checkTypes.set([mockCheckType])
+      expect($hasCheckTypes.get()).toBe(true)
+    })
+
+    it('should return 0 for $checkTypeCount when list is empty', () => {
+      expect($checkTypeCount.get()).toBe(0)
+    })
+
+    it('should return correct count for $checkTypeCount', () => {
+      $checkTypes.set([mockCheckType, mockCheckType2])
+
+      expect($checkTypeCount.get()).toBe(2)
+    })
+  })
+
+  describe('checkTypeActions', () => {
+    describe('fetchByVehicle', () => {
+      it('should fetch and set check types on success', async () => {
+        const apiResponse = [mockCheckType, mockCheckType2]
+
+        getSpy.mockResolvedValueOnce({ data: apiResponse, success: true })
+
+        await checkTypeActions.fetchByVehicle('v1')
+
+        expect(getSpy).toHaveBeenCalledWith('/vehicles/v1/check-types')
+        expect($checkTypes.get()).toEqual(apiResponse)
+        expect($error.get()).toBeNull()
+      })
+
+      it('should set empty array when no check types exist', async () => {
+        getSpy.mockResolvedValueOnce({ data: [], success: true })
+
+        await checkTypeActions.fetchByVehicle('v1')
+
+        expect(getSpy).toHaveBeenCalledWith('/vehicles/v1/check-types')
+        expect($checkTypes.get()).toEqual([])
+        expect($error.get()).toBeNull()
+      })
+
+      it('should set error on failure', async () => {
+        getSpy.mockResolvedValueOnce({ data: null, success: false })
+
+        await checkTypeActions.fetchByVehicle('v1')
+
+        expect(getSpy).toHaveBeenCalledWith('/vehicles/v1/check-types')
+        expect($checkTypes.get()).toEqual([])
+        expect($error.get()).toBe('API request failed')
+      })
+
+      it('should manage loading state during fetch', async () => {
+        const apiResponse = { data: [mockCheckType], success: true }
+
+        getSpy.mockResolvedValueOnce(apiResponse)
+
+        const fetchPromise = checkTypeActions.fetchByVehicle('v1')
+
+        expect($isLoading.get()).toBe(true)
+
+        await fetchPromise
+
+        expect($isLoading.get()).toBe(false)
+      })
+    })
+
+    describe('create', () => {
+      it('should create check type and append to list on success', async () => {
+        const newCheckType = {
+          name: 'Brake Check',
+          intervalDays: 30
+        }
+        const createdCheckType = { ...mockCheckType, ...newCheckType, id: 'ct3' }
+        const apiResponse = { data: createdCheckType, success: true }
+
+        postSpy.mockResolvedValueOnce(apiResponse)
+
+        // Pre-populate store with existing check type
+        $checkTypes.set([mockCheckType])
+
+        const result = await checkTypeActions.create('v1', newCheckType)
+
+        expect(postSpy).toHaveBeenCalledWith('/vehicles/v1/check-types', newCheckType)
+        expect($checkTypes.get()).toEqual([mockCheckType, createdCheckType])
+        expect($error.get()).toBeNull()
+        expect(result).toEqual(createdCheckType)
+      })
+
+      it('should set error on creation failure', async () => {
+        const newCheckType = {
+          name: 'Brake Check',
+          intervalDays: 30
+        }
+        const errorMessage = 'Failed to create check type'
+
+        postSpy.mockRejectedValueOnce(new Error(errorMessage))
+
+        await expect(checkTypeActions.create('v1', newCheckType)).rejects.toThrow(errorMessage)
+
+        expect(postSpy).toHaveBeenCalledWith('/vehicles/v1/check-types', newCheckType)
+        expect($error.get()).toBe(errorMessage)
+      })
+    })
+
+    describe('update', () => {
+      it('should update check type and replace in list on success', async () => {
+        const updatedData = { name: 'Updated Oil Check', intervalDays: 10 }
+        const updatedCheckType = { ...mockCheckType, ...updatedData }
+        const apiResponse = { data: updatedCheckType, success: true }
+
+        patchSpy.mockResolvedValueOnce(apiResponse)
+
+        // Pre-populate store with existing check type
+        $checkTypes.set([mockCheckType])
+
+        const result = await checkTypeActions.update('v1', 'ct1', updatedData)
+
+        expect(patchSpy).toHaveBeenCalledWith('/vehicles/v1/check-types/ct1', updatedData)
+        expect($checkTypes.get()).toEqual([updatedCheckType])
+        expect($error.get()).toBeNull()
+        expect(result).toEqual(updatedCheckType)
+      })
+
+      it('should set error on update failure', async () => {
+        const updatedData = { name: 'Updated Oil Check', intervalDays: 10 }
+        const errorMessage = 'Failed to update check type'
+
+        patchSpy.mockRejectedValueOnce(new Error(errorMessage))
+
+        await expect(checkTypeActions.update('v1', 'ct1', updatedData)).rejects.toThrow(
+          errorMessage
+        )
+
+        expect(patchSpy).toHaveBeenCalledWith('/vehicles/v1/check-types/ct1', updatedData)
+        expect($error.get()).toBe(errorMessage)
+      })
+    })
+
+    describe('remove', () => {
+      it('should delete check type and remove from list on success', async () => {
+        const apiResponse = { success: true }
+
+        deleteSpy.mockResolvedValueOnce(apiResponse)
+
+        // Pre-populate store with existing check type
+        $checkTypes.set([mockCheckType])
+
+        await checkTypeActions.remove('v1', 'ct1')
+
+        expect(deleteSpy).toHaveBeenCalledWith('/vehicles/v1/check-types/ct1')
+        expect($checkTypes.get()).toEqual([])
+        expect($error.get()).toBeNull()
+      })
+
+      it('should set error on deletion failure', async () => {
+        const errorMessage = 'Failed to delete check type'
+
+        deleteSpy.mockRejectedValueOnce(new Error(errorMessage))
+
+        await expect(checkTypeActions.remove('v1', 'ct1')).rejects.toThrow(errorMessage)
+
+        expect(deleteSpy).toHaveBeenCalledWith('/vehicles/v1/check-types/ct1')
+        expect($error.get()).toBe(errorMessage)
+      })
+    })
+
+    describe('clearError', () => {
+      it('should clear error state', () => {
+        $error.set('Some error')
+
+        checkTypeActions.clearError()
+
+        expect($error.get()).toBeNull()
+      })
+    })
+  })
+})

--- a/apps/web/src/features/check-types/store/checkType.store.ts
+++ b/apps/web/src/features/check-types/store/checkType.store.ts
@@ -1,0 +1,91 @@
+import { atom, computed } from 'nanostores'
+
+import { createCheckType, deleteCheckType, getCheckTypes, updateCheckType } from '../api'
+import type { CreateCheckTypeSchema, UpdateCheckTypeSchema } from '../schemas'
+import type { CheckType } from '../types'
+
+// State atoms
+export const $checkTypes = atom<CheckType[]>([])
+export const $isLoading = atom<boolean>(false)
+export const $error = atom<string | null>(null)
+
+// Computed values
+export const $hasCheckTypes = computed($checkTypes, checkTypes => checkTypes.length > 0)
+export const $checkTypeCount = computed($checkTypes, checkTypes => checkTypes.length)
+
+export const checkTypeActions = {
+  async fetchByVehicle(vehicleId: string) {
+    $isLoading.set(true)
+    $error.set(null)
+
+    try {
+      const response = await getCheckTypes(vehicleId)
+
+      $checkTypes.set(response)
+
+      return response
+    } catch (error) {
+      $checkTypes.set([])
+      $error.set(error instanceof Error ? error.message : 'Unknown error')
+    } finally {
+      $isLoading.set(false)
+    }
+  },
+  async create(vehicleId: string, data: CreateCheckTypeSchema): Promise<CheckType> {
+    $isLoading.set(true)
+    $error.set(null)
+
+    try {
+      const response = await createCheckType(vehicleId, data)
+
+      $checkTypes.set([...$checkTypes.get(), response])
+
+      return response
+    } catch (error) {
+      $error.set(error instanceof Error ? error.message : 'Unknown error')
+
+      throw error
+    } finally {
+      $isLoading.set(false)
+    }
+  },
+  async update(vehicleId: string, id: string, data: UpdateCheckTypeSchema): Promise<CheckType> {
+    $isLoading.set(true)
+    $error.set(null)
+
+    try {
+      const response = await updateCheckType(vehicleId, id, data)
+
+      $checkTypes.set(
+        $checkTypes.get().map(checkType => (checkType.id === id ? response : checkType))
+      )
+
+      return response
+    } catch (error) {
+      $error.set(error instanceof Error ? error.message : 'Unknown error')
+
+      throw error
+    } finally {
+      $isLoading.set(false)
+    }
+  },
+  async remove(vehicleId: string, id: string): Promise<void> {
+    $isLoading.set(true)
+    $error.set(null)
+
+    try {
+      await deleteCheckType(vehicleId, id)
+
+      $checkTypes.set($checkTypes.get().filter(checkType => checkType.id !== id))
+    } catch (error) {
+      $error.set(error instanceof Error ? error.message : 'Unknown error')
+
+      throw error
+    } finally {
+      $isLoading.set(false)
+    }
+  },
+  clearError() {
+    $error.set(null)
+  }
+}

--- a/apps/web/src/features/check-types/store/index.ts
+++ b/apps/web/src/features/check-types/store/index.ts
@@ -1,0 +1,8 @@
+export {
+  $checkTypeCount,
+  $checkTypes,
+  $error,
+  $hasCheckTypes,
+  $isLoading,
+  checkTypeActions
+} from './checkType.store'

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -24,24 +24,24 @@
 
 ---
 
-## Phase 8: API Service
+## Phase 8: API Service ✅
 
-- [ ] checkType.service.ts + tests
-- [ ] api/index.ts barrel
-
----
-
-## Phase 9: State Store
-
-- [ ] checkType.store.ts + tests
-- [ ] store/index.ts barrel
+- [x] checkType.service.ts + tests
+- [x] api/index.ts barrel
 
 ---
 
-## Phase 10: Hook
+## Phase 9: State Store ✅
 
-- [ ] useCheckTypes.ts + tests
-- [ ] hooks/index.ts barrel
+- [x] checkType.store.ts + tests
+- [x] store/index.ts barrel
+
+---
+
+## Phase 10: Hook ✅
+
+- [x] useCheckTypes.ts + tests
+- [x] hooks/index.ts barrel
 
 ---
 


### PR DESCRIPTION
## Summary

- **API Service**: CRUD functions for `/vehicles/:vehicleId/check-types` with full test coverage
- **State Store**: Nanostores atoms (`$checkTypes`, `$isLoading`, `$error`), computed values (`$hasCheckTypes`, `$checkTypeCount`), and actions (`fetchByVehicle`, `create`, `update`, `remove`)
- **Hook**: `useCheckTypes` React hook bridging nanostores to components. `fetchByVehicle` is memoized via `useCallback` for use in `useEffect` dependency arrays; mutation actions (`create`, `update`, `remove`) are inline since they are called from event handlers only

## Details

Block 2 of the check-types frontend feature (Phases 8-10). Builds the data layer that UI components (Block 3) will consume.

All service functions take `vehicleId` as first parameter since check-type endpoints are nested under `/vehicles/:vehicleId/check-types`.

## Test plan

- [x] API service tests: mocked `api` client, all CRUD operations including null data edge case
- [x] Store tests: all atoms, computed values, and action flows (success + error)
- [x] Hook tests: reactive state from store + action delegation
- [x] All 428 tests pass
- [x] Typecheck, lint, format all pass