### PR TITLE
feat(check-types): add container, list, and card components

### DIFF
--- a/apps/web/src/features/check-types/components/CheckTypeCard.spec.tsx
+++ b/apps/web/src/features/check-types/components/CheckTypeCard.spec.tsx
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, mock } from 'bun:test'
+
+import { cleanup, fireEvent, render, screen } from '~/test-utils'
+
+import type { CheckType } from '../types'
+
+import { CheckTypeCard } from './CheckTypeCard'
+
+const mockCheckType: CheckType = {
+  id: 'ct-1',
+  vehicleId: 'v-1',
+  name: `Niveau d'huile`,
+  description: `Vérifier le niveau d'huile moteur`,
+  intervalDays: 7,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z'
+}
+
+const mockCheckTypeNoDescription: CheckType = {
+  ...mockCheckType,
+  id: 'ct-2',
+  description: null
+}
+
+describe('CheckTypeCard', () => {
+  beforeEach(() => {
+    cleanup()
+    document.body.innerHTML = ''
+  })
+
+  it('should render the check type name', () => {
+    const actions = mock(() => {})
+    render(<CheckTypeCard checkType={mockCheckType} onEdit={actions} onDelete={actions} />)
+
+    expect(screen.getByText(mockCheckType.name)).toBeInTheDocument()
+  })
+
+  it('should render the description when present', () => {
+    const actions = mock(() => {})
+    render(<CheckTypeCard checkType={mockCheckType} onEdit={actions} onDelete={actions} />)
+
+    expect(screen.getByText(mockCheckType.description!)).toBeInTheDocument()
+  })
+
+  it('should not render description when null', () => {
+    const actions = mock(() => {})
+    render(
+      <CheckTypeCard checkType={mockCheckTypeNoDescription} onEdit={actions} onDelete={actions} />
+    )
+
+    expect(screen.queryByText(mockCheckType.description!)).toBeNull()
+  })
+
+  it('should render the interval in French format', () => {
+    const actions = mock(() => {})
+    render(<CheckTypeCard checkType={mockCheckType} onEdit={actions} onDelete={actions} />)
+
+    expect(screen.getByText(`Tous les ${mockCheckType.intervalDays} jours`)).toBeInTheDocument()
+  })
+
+  it('should render edit and delete buttons', () => {
+    const actions = mock(() => {})
+    render(<CheckTypeCard checkType={mockCheckType} onEdit={actions} onDelete={actions} />)
+
+    expect(screen.getByRole('button', { name: /modifier/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /supprimer/i })).toBeInTheDocument()
+  })
+
+  it('should call onEdit with check type when edit button clicked', () => {
+    const onEdit = mock(() => {})
+    const onDelete = mock(() => {})
+    render(<CheckTypeCard checkType={mockCheckType} onEdit={onEdit} onDelete={onDelete} />)
+
+    const editButton = screen.getByRole('button', { name: /modifier/i })
+    fireEvent.click(editButton)
+
+    expect(onEdit).toHaveBeenCalledWith(mockCheckType)
+  })
+
+  it('should call onDelete with check type when delete button clicked', () => {
+    const onEdit = mock(() => {})
+    const onDelete = mock(() => {})
+    render(<CheckTypeCard checkType={mockCheckType} onEdit={onEdit} onDelete={onDelete} />)
+
+    const deleteButton = screen.getByRole('button', { name: /supprimer/i })
+    fireEvent.click(deleteButton)
+
+    expect(onDelete).toHaveBeenCalledWith(mockCheckType)
+  })
+})

--- a/apps/web/src/features/check-types/components/CheckTypeCard.tsx
+++ b/apps/web/src/features/check-types/components/CheckTypeCard.tsx
@@ -1,0 +1,27 @@
+import { Button } from '~/components/ui'
+
+import type { CheckType } from '../types'
+
+export interface CheckTypeCardProps {
+  checkType: CheckType
+  onEdit: (checkType: CheckType) => void
+  onDelete: (checkType: CheckType) => void
+}
+
+export const CheckTypeCard = ({ checkType, onEdit, onDelete }: CheckTypeCardProps) => {
+  const formattedInterval = `Tous les ${checkType.intervalDays} jours`
+
+  return (
+    <article className='rounded-lg border border-zinc-700 bg-zinc-800 p-4'>
+      <h2 className='text-zinc-100'>{checkType.name}</h2>
+      {checkType.description && <p className='text-zinc-300'>{checkType.description}</p>}
+      <p className='text-zinc-300'>{formattedInterval}</p>
+      <footer className='mx-auto my-6 flex w-full max-w-lg items-center justify-between gap-2'>
+        <Button onClick={() => onEdit(checkType)}>Modifier</Button>
+        <Button variant='destructive' onClick={() => onDelete(checkType)}>
+          Supprimer
+        </Button>
+      </footer>
+    </article>
+  )
+}

--- a/apps/web/src/features/check-types/components/CheckTypeContainer.spec.tsx
+++ b/apps/web/src/features/check-types/components/CheckTypeContainer.spec.tsx
@@ -1,0 +1,126 @@
+import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from 'bun:test'
+
+// Direct store imports: bun:test mock.module leaks globally across files,
+// so mocking ~/features/vehicles breaks the vehicles feature's own tests.
+// Using internal paths for test state setup is the pragmatic workaround.
+import type { Vehicle } from '~/features/vehicles'
+import {
+  $isLoading as $isVehicleLoading,
+  $vehicle,
+  vehicleActions
+} from '~/features/vehicles/store'
+import { cleanup, render, screen } from '~/test-utils'
+import * as navigationUtils from '~/utils/navigation'
+
+import { $checkTypes, $error, $isLoading, checkTypeActions } from '../store'
+import type { CheckType } from '../types'
+
+import { CheckTypeContainer } from './CheckTypeContainer'
+
+mock.module('~/utils/navigation', () => ({
+  redirect: mock(() => {})
+}))
+
+const mockVehicle: Vehicle = {
+  id: 'v-1',
+  userId: 'u-1',
+  make: 'Mini',
+  model: 'Cooper',
+  year: 2020,
+  engineType: '1.5L Turbo',
+  fuelType: 'GASOLINE',
+  vin: null,
+  licensePlate: 'AB-123-CD',
+  purchaseDate: null,
+  mileage: 45000,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z'
+}
+
+const mockCheckTypes: CheckType[] = [
+  {
+    id: 'ct-1',
+    vehicleId: 'v-1',
+    name: `Niveau d'huile`,
+    description: `Vérifier le niveau d'huile moteur`,
+    intervalDays: 7,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z'
+  },
+  {
+    id: 'ct-2',
+    vehicleId: 'v-1',
+    name: 'Pression des pneus',
+    description: null,
+    intervalDays: 14,
+    createdAt: '2026-01-02T00:00:00.000Z',
+    updatedAt: '2026-01-02T00:00:00.000Z'
+  }
+]
+
+describe('CheckTypeContainer', () => {
+  let fetchCheckTypesSpy: ReturnType<typeof spyOn>
+  let fetchVehicleSpy: ReturnType<typeof spyOn>
+
+  beforeEach(() => {
+    cleanup()
+    document.body.innerHTML = ''
+
+    $vehicle.set(null)
+    $isVehicleLoading.set(false)
+    $checkTypes.set([])
+    $isLoading.set(false)
+    $error.set(null)
+
+    fetchCheckTypesSpy = spyOn(checkTypeActions, 'fetchByVehicle').mockResolvedValue(undefined)
+    fetchVehicleSpy = spyOn(vehicleActions, 'fetchVehicle').mockResolvedValue(undefined)
+  })
+
+  afterEach(() => {
+    fetchCheckTypesSpy.mockRestore()
+    fetchVehicleSpy.mockRestore()
+  })
+
+  it('should show loading state', () => {
+    $isVehicleLoading.set(true)
+    render(<CheckTypeContainer />)
+
+    expect(screen.getByText('Chargement...')).toBeVisible()
+  })
+
+  it('should redirect when no vehicle exists', () => {
+    $vehicle.set(null)
+    $isVehicleLoading.set(false)
+
+    render(<CheckTypeContainer />)
+
+    expect(navigationUtils.redirect).toHaveBeenCalledWith('/vehicle')
+  })
+
+  it('should fetch check types when vehicle is available', () => {
+    $vehicle.set(mockVehicle)
+
+    render(<CheckTypeContainer />)
+
+    expect(fetchCheckTypesSpy).toHaveBeenCalledWith(mockVehicle.id)
+  })
+
+  it('should render check type list when data is loaded', () => {
+    $vehicle.set(mockVehicle)
+    $checkTypes.set(mockCheckTypes)
+
+    render(<CheckTypeContainer />)
+
+    expect(screen.getByText(`Niveau d'huile`)).toBeVisible()
+    expect(screen.getByText('Pression des pneus')).toBeVisible()
+  })
+
+  it('should render empty list when no check types exist', () => {
+    $vehicle.set(mockVehicle)
+    $checkTypes.set([])
+
+    render(<CheckTypeContainer />)
+
+    expect(screen.getByText('Aucun type de contrôle trouvé. Veuillez en ajouter un.')).toBeVisible()
+  })
+})

--- a/apps/web/src/features/check-types/components/CheckTypeContainer.tsx
+++ b/apps/web/src/features/check-types/components/CheckTypeContainer.tsx
@@ -1,0 +1,51 @@
+import { useEffect, useState } from 'react'
+
+import { useVehicle } from '~/features/vehicles'
+import { redirect } from '~/utils/navigation'
+
+import { useCheckTypes } from '../hooks'
+import type { CheckType } from '../types'
+
+import { CheckTypeList } from './CheckTypeList'
+
+export const CheckTypeContainer = () => {
+  const [mode, setMode] = useState<'loading' | 'list' | 'create' | 'edit'>('loading')
+  const { vehicle, fetchVehicle, hasVehicle, isLoading: isVehicleLoading } = useVehicle()
+  const { checkTypes, isLoading: isCheckTypesLoading, fetchByVehicle } = useCheckTypes()
+
+  useEffect(() => {
+    fetchVehicle()
+  }, [fetchVehicle])
+
+  useEffect(() => {
+    if (hasVehicle && vehicle) {
+      fetchByVehicle(vehicle.id)
+    }
+  }, [hasVehicle, vehicle, fetchByVehicle])
+
+  useEffect(() => {
+    if (vehicle && !isCheckTypesLoading) {
+      setMode('list')
+    }
+  }, [vehicle, isCheckTypesLoading])
+
+  // Stubs for now (Phase 12 form, Phase 14 delete dialog)
+  const onEdit = (_checkType: CheckType) => {}
+  const onDelete = (_checkType: CheckType) => {}
+
+  if (!vehicle && !isVehicleLoading && !hasVehicle) {
+    redirect('/vehicle')
+    return null
+  }
+
+  if (mode === 'loading') {
+    return <p>Chargement...</p>
+  }
+
+  return (
+    <section className='p-4'>
+      <h1 className='mb-4 text-2xl font-bold text-zinc-100'>Types de contrôle</h1>
+      <CheckTypeList checkTypes={checkTypes} onEdit={onEdit} onDelete={onDelete} />
+    </section>
+  )
+}

--- a/apps/web/src/features/check-types/components/CheckTypeList.spec.tsx
+++ b/apps/web/src/features/check-types/components/CheckTypeList.spec.tsx
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, mock } from 'bun:test'
+
+import { cleanup, fireEvent, render, screen } from '~/test-utils'
+
+import type { CheckType } from '../types'
+
+import { CheckTypeList } from './CheckTypeList'
+
+const mockCheckTypes: CheckType[] = [
+  {
+    id: 'ct-1',
+    vehicleId: 'v-1',
+    name: "Niveau d'huile",
+    description: "Vérifier le niveau d'huile moteur",
+    intervalDays: 7,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z'
+  },
+  {
+    id: 'ct-2',
+    vehicleId: 'v-1',
+    name: 'Pression des pneus',
+    description: null,
+    intervalDays: 14,
+    createdAt: '2026-01-02T00:00:00.000Z',
+    updatedAt: '2026-01-02T00:00:00.000Z'
+  }
+]
+
+describe('CheckTypeList', () => {
+  beforeEach(() => {
+    cleanup()
+    document.body.innerHTML = ''
+  })
+
+  it('should render a card for each check type', () => {
+    const actions = mock(() => {})
+    render(<CheckTypeList checkTypes={mockCheckTypes} onEdit={actions} onDelete={actions} />)
+
+    const cards = screen.getAllByRole('article')
+
+    expect(cards).toHaveLength(mockCheckTypes.length)
+  })
+
+  // Temporary: empty state will be handled by CheckTypeEmptyState (Phase 13)
+  // This test will be removed when the Container delegates empty state rendering
+  it('should render empty message when list is empty', () => {
+    const actions = mock(() => {})
+    render(<CheckTypeList checkTypes={[]} onEdit={actions} onDelete={actions} />)
+
+    const cards = screen.queryAllByRole('article')
+
+    expect(cards).toHaveLength(0)
+    expect(
+      screen.getByText('Aucun type de contrôle trouvé. Veuillez en ajouter un.')
+    ).toBeInTheDocument()
+  })
+
+  it('should pass onEdit callback to cards', () => {
+    const onEdit = mock(() => {})
+    const onDelete = mock(() => {})
+    render(<CheckTypeList checkTypes={mockCheckTypes} onEdit={onEdit} onDelete={onDelete} />)
+
+    const editButtons = screen.getAllByRole('button', { name: /modifier/i })
+    editButtons.forEach((button, index) => {
+      fireEvent.click(button)
+      expect(onEdit).toHaveBeenCalledWith(mockCheckTypes[index])
+    })
+  })
+
+  it('should pass onDelete callback to cards', () => {
+    const onEdit = mock(() => {})
+    const onDelete = mock(() => {})
+    render(<CheckTypeList checkTypes={mockCheckTypes} onEdit={onEdit} onDelete={onDelete} />)
+
+    const deleteButtons = screen.getAllByRole('button', { name: /supprimer/i })
+
+    deleteButtons.forEach((button, index) => {
+      fireEvent.click(button)
+      expect(onDelete).toHaveBeenCalledWith(mockCheckTypes[index])
+    })
+  })
+})

--- a/apps/web/src/features/check-types/components/CheckTypeList.tsx
+++ b/apps/web/src/features/check-types/components/CheckTypeList.tsx
@@ -1,0 +1,31 @@
+import type { CheckType } from '../types'
+
+import { CheckTypeCard } from './CheckTypeCard'
+
+export interface CheckTypeListProps {
+  checkTypes: CheckType[]
+  onEdit: (checkType: CheckType) => void
+  onDelete: (checkType: CheckType) => void
+}
+
+export const CheckTypeList = ({ checkTypes, onEdit, onDelete }: CheckTypeListProps) => {
+  // Temporary: will be replaced by CheckTypeEmptyState component (Phase 13)
+  const emptyCheckTypesMessage = 'Aucun type de contrôle trouvé. Veuillez en ajouter un.'
+
+  return (
+    <section className='grid gap-2'>
+      {checkTypes.length > 0 ? (
+        checkTypes.map(checkType => (
+          <CheckTypeCard
+            key={checkType.id}
+            checkType={checkType}
+            onEdit={onEdit}
+            onDelete={onDelete}
+          />
+        ))
+      ) : (
+        <p>{emptyCheckTypesMessage}</p>
+      )}
+    </section>
+  )
+}

--- a/apps/web/src/features/check-types/components/index.ts
+++ b/apps/web/src/features/check-types/components/index.ts
@@ -1,0 +1,5 @@
+export { CheckTypeCard } from './CheckTypeCard'
+export type { CheckTypeCardProps } from './CheckTypeCard'
+export { CheckTypeContainer } from './CheckTypeContainer'
+export { CheckTypeList } from './CheckTypeList'
+export type { CheckTypeListProps } from './CheckTypeList'

--- a/apps/web/src/features/vehicles/index.ts
+++ b/apps/web/src/features/vehicles/index.ts
@@ -1,1 +1,4 @@
 export { VehicleContainer } from './components'
+export { useVehicle } from './hooks'
+export type { UseVehicleReturn } from './hooks'
+export type { Vehicle } from './types'

--- a/apps/web/src/pages/check-types/index.astro
+++ b/apps/web/src/pages/check-types/index.astro
@@ -1,4 +1,5 @@
 ---
+import { CheckTypeContainer } from '~/features/check-types/components'
 import Main from '~/layouts/Main.astro'
 
 const { user } = Astro.locals
@@ -10,6 +11,6 @@ if (!user) {
 
 <Main title='Contrôles'>
   <section class='container mx-auto px-4 py-8'>
-    <p>Check Types Container Placeholder</p>
+    <CheckTypeContainer client:only='react' />
   </section>
 </Main>

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -55,8 +55,9 @@
 
 ---
 
-## Phase 12: Form
+## Phase 12: Textarea UI + Form
 
+- [ ] Textarea.tsx + tests (shared UI component)
 - [ ] CheckTypeForm.tsx + tests
 
 ---

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -45,13 +45,13 @@
 
 ---
 
-## Phase 11: Container + List + Card
+## Phase 11: Container + List + Card ✅
 
-- [ ] CheckTypeCard.tsx + tests
-- [ ] CheckTypeList.tsx + tests
-- [ ] CheckTypeContainer.tsx + tests
-- [ ] components/index.ts barrel
-- [ ] Update Astro page to mount CheckTypeContainer
+- [x] CheckTypeCard.tsx + tests
+- [x] CheckTypeList.tsx + tests
+- [x] CheckTypeContainer.tsx + tests
+- [x] components/index.ts barrel
+- [x] Update Astro page to mount CheckTypeContainer
 
 ---
 


### PR DESCRIPTION
## Summary

- Add CheckTypeCard presentational component displaying check type details (name, interval, description, edit/delete actions)
- Add CheckTypeList component rendering cards with empty state handling
- Add CheckTypeContainer orchestrator with mode state (loading/list/create/edit) and stub CRUD handlers
- Mount CheckTypeContainer in Astro page replacing placeholder
- Export additional types from vehicles feature barrel (dependency for cross-feature import)
- Update Phase 12 plan to include Textarea shared UI component

## Test plan

- [x] All existing tests pass (`bun run test`)
- [x] Typecheck passes (`bun run typecheck`)
- [ ] Navigate to `/check-types` — container renders in list mode
- [ ] Verify card displays name, interval, description
- [ ] Verify empty state shown when no check types exist