### PR TITLE
feat(web): migrate shared UI components to DaisyUI + Radix UI

### DIFF
--- a/apps/web/src/components/ui/Button.spec.tsx
+++ b/apps/web/src/components/ui/Button.spec.tsx
@@ -23,7 +23,8 @@ describe('Button', () => {
 
     const button = getByRole('button', { name: 'Default' })
 
-    expect(button).toHaveClass('bg-sky-400')
+    expect(button).toHaveClass('btn-primary')
+    expect(button).toHaveClass('btn')
   })
 
   it('should apply outline variant styling', () => {
@@ -31,7 +32,8 @@ describe('Button', () => {
 
     const button = getByRole('button', { name: 'Outline' })
 
-    expect(button).toHaveClass('border-zinc-700')
+    expect(button).toHaveClass('btn-outline')
+    expect(button).toHaveClass('btn')
   })
 
   it('should apply ghost variant styling', () => {
@@ -39,7 +41,8 @@ describe('Button', () => {
 
     const button = getByRole('button', { name: 'Ghost' })
 
-    expect(button).toHaveClass('hover:bg-zinc-800')
+    expect(button).toHaveClass('btn-ghost')
+    expect(button).toHaveClass('btn')
   })
 
   it('should apply destructive variant styling', () => {
@@ -47,7 +50,8 @@ describe('Button', () => {
 
     const button = getByRole('button', { name: 'Destructive' })
 
-    expect(button).toHaveClass('bg-red-900')
+    expect(button).toHaveClass('btn-error')
+    expect(button).toHaveClass('btn')
   })
 
   it('should be disabled when disabled prop is true', () => {

--- a/apps/web/src/components/ui/Button.tsx
+++ b/apps/web/src/components/ui/Button.tsx
@@ -18,17 +18,15 @@ export type ButtonProps = ButtonAsButton | (ButtonAsAnchor & { as: 'a' })
 
 export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   ({ variant = 'default', children, className = '', disabled, as, ...rest }, ref) => {
-    const baseClasses =
-      'w-fit rounded-lg px-4 py-2 font-medium focus:outline-none focus:ring-2 focus:ring-amber-400 focus:ring-offset-2 focus:ring-offset-zinc-900 disabled:opacity-70 transition-colors'
+    const baseClasses = 'btn'
     const variantClasses = {
-      default: 'bg-sky-400 text-zinc-900 hover:bg-sky-400/85 border-2 border-transparent',
-      outline: 'bg-transparent border-2 border-zinc-700 text-zinc-300 hover:bg-zinc-800',
-      ghost:
-        'bg-transparent text-zinc-300 hover:bg-zinc-800 hover:text-zinc-200 border-2 border-transparent',
-      destructive: 'bg-red-900 text-red-300 hover:bg-red-900/85 border-2 border-transparent'
+      default: 'btn-primary',
+      outline: 'btn-outline',
+      ghost: 'btn-ghost',
+      destructive: 'btn-error'
     }
 
-    const combinedClasses = `${baseClasses} ${variantClasses[variant]} ${disabled ? 'cursor-not-allowed' : as ? '' : 'cursor-pointer'} ${className}`
+    const combinedClasses = `${baseClasses} ${variantClasses[variant]} ${className}`
     const Component = as || 'button'
 
     return (

--- a/apps/web/src/components/ui/ConfirmDialog.spec.tsx
+++ b/apps/web/src/components/ui/ConfirmDialog.spec.tsx
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, mock } from 'bun:test'
 
-import { cleanup, render, screen } from '~/test-utils'
+import { cleanup, fireEvent, render, screen } from '~/test-utils'
 
 import { ConfirmDialog } from './ConfirmDialog'
 
@@ -13,124 +13,119 @@ describe('ConfirmDialog', () => {
   it('should render the title', () => {
     render(
       <ConfirmDialog
-        title='Supprimer ?'
-        message='Cette action est irréversible.'
+        title='Test Title'
+        message='Test Message'
         onConfirm={() => {}}
         onCancel={() => {}}
       />
     )
 
-    expect(screen.getByText('Supprimer ?')).toBeInTheDocument()
+    expect(screen.getByText('Test Title')).toBeInTheDocument()
   })
 
   it('should render the message', () => {
     render(
       <ConfirmDialog
-        title='Supprimer ?'
-        message='Cette action est irréversible.'
+        title='Test Title'
+        message='Test Message'
         onConfirm={() => {}}
         onCancel={() => {}}
       />
     )
 
-    expect(screen.getByText('Cette action est irréversible.')).toBeInTheDocument()
+    expect(screen.getByText('Test Message')).toBeInTheDocument()
   })
 
   it('should render confirm and cancel buttons with default labels', () => {
     render(
       <ConfirmDialog
-        title='Supprimer ?'
-        message='Cette action est irréversible.'
+        title='Test Title'
+        message='Test Message'
         onConfirm={() => {}}
         onCancel={() => {}}
       />
     )
 
-    expect(screen.getByRole('button', { name: /Confirmer/i })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /Annuler/i })).toBeInTheDocument()
+    expect(screen.getByText('Confirmer')).toBeInTheDocument()
+    expect(screen.getByText('Annuler')).toBeInTheDocument()
   })
 
   it('should render confirm and cancel buttons with custom labels', () => {
     render(
       <ConfirmDialog
-        title='Supprimer ?'
-        message='Cette action est irréversible.'
-        confirmLabel='Supprimer'
-        cancelLabel='Retour'
+        title='Test Title'
+        message='Test Message'
+        confirmLabel='Yes'
+        cancelLabel='No'
         onConfirm={() => {}}
         onCancel={() => {}}
       />
     )
 
-    expect(screen.getByRole('button', { name: /Supprimer/i })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /Retour/i })).toBeInTheDocument()
+    expect(screen.getByText('Yes')).toBeInTheDocument()
+    expect(screen.getByText('No')).toBeInTheDocument()
   })
 
   it('should call onConfirm when confirm button is clicked', () => {
     const onConfirm = mock(() => {})
+
     render(
       <ConfirmDialog
-        title='Supprimer ?'
-        message='Cette action est irréversible.'
+        title='Test Title'
+        message='Test Message'
         onConfirm={onConfirm}
         onCancel={() => {}}
       />
     )
 
-    const confirmButton = screen.getByRole('button', { name: /Confirmer/i })
-    confirmButton.click()
-
+    fireEvent.click(screen.getByText('Confirmer'))
     expect(onConfirm).toHaveBeenCalledTimes(1)
   })
 
   it('should call onCancel when cancel button is clicked', () => {
     const onCancel = mock(() => {})
+
     render(
       <ConfirmDialog
-        title='Supprimer ?'
-        message='Cette action est irréversible.'
+        title='Test Title'
+        message='Test Message'
         onConfirm={() => {}}
         onCancel={onCancel}
       />
     )
 
-    const cancelButton = screen.getByRole('button', { name: /Annuler/i })
-    cancelButton.click()
-
+    fireEvent.click(screen.getByText('Annuler'))
     expect(onCancel).toHaveBeenCalledTimes(1)
   })
 
   it('should call onCancel when backdrop is clicked', () => {
     const onCancel = mock(() => {})
+
     render(
       <ConfirmDialog
-        title='Supprimer ?'
-        message='Cette action est irréversible.'
+        title='Test Title'
+        message='Test Message'
         onConfirm={() => {}}
         onCancel={onCancel}
       />
     )
 
-    const backdrop = screen.getByRole('dialog').parentElement!
-    backdrop.click()
-
+    const overlay = document.querySelector('.fixed.inset-0')
+    fireEvent.click(overlay!)
     expect(onCancel).toHaveBeenCalledTimes(1)
   })
 
-  it('should call onCancel when Escape key is pressed', () => {
-    const onCancel = mock(() => {})
+  it('should use DaisyUI modal-box class on content', () => {
     render(
       <ConfirmDialog
-        title='Supprimer ?'
-        message='Cette action est irréversible.'
+        title='Test Title'
+        message='Test Message'
         onConfirm={() => {}}
-        onCancel={onCancel}
+        onCancel={() => {}}
       />
     )
 
-    const event = new KeyboardEvent('keydown', { key: 'Escape' })
-    document.dispatchEvent(event)
-
-    expect(onCancel).toHaveBeenCalledTimes(1)
+    expect(screen.getByRole('dialog')).toHaveClass('modal')
+    expect(screen.getByRole('dialog')).toHaveClass('modal-open')
   })
 })

--- a/apps/web/src/components/ui/ConfirmDialog.spec.tsx
+++ b/apps/web/src/components/ui/ConfirmDialog.spec.tsx
@@ -115,6 +115,22 @@ describe('ConfirmDialog', () => {
     expect(onCancel).toHaveBeenCalledTimes(1)
   })
 
+  it('should call onCancel when Escape key is pressed', () => {
+    const onCancel = mock(() => {})
+
+    render(
+      <ConfirmDialog
+        title='Test Title'
+        message='Test Message'
+        onConfirm={() => {}}
+        onCancel={onCancel}
+      />
+    )
+
+    fireEvent.keyDown(screen.getByRole('dialog'), { key: 'Escape' })
+    expect(onCancel).toHaveBeenCalledTimes(1)
+  })
+
   it('should use DaisyUI modal-box class on content', () => {
     render(
       <ConfirmDialog

--- a/apps/web/src/components/ui/ConfirmDialog.spec.tsx
+++ b/apps/web/src/components/ui/ConfirmDialog.spec.tsx
@@ -131,7 +131,7 @@ describe('ConfirmDialog', () => {
     expect(onCancel).toHaveBeenCalledTimes(1)
   })
 
-  it('should use DaisyUI modal-box class on content', () => {
+  it('should use DaisyUI modal classes on dialog', () => {
     render(
       <ConfirmDialog
         title='Test Title'
@@ -141,7 +141,10 @@ describe('ConfirmDialog', () => {
       />
     )
 
-    expect(screen.getByRole('dialog')).toHaveClass('modal')
-    expect(screen.getByRole('dialog')).toHaveClass('modal-open')
+    const dialog = screen.getByRole('dialog')
+    expect(dialog).toHaveClass('modal')
+    expect(dialog).toHaveClass('modal-open')
+    expect(dialog.querySelector('.modal-box')).toBeInTheDocument()
+    expect(dialog.querySelector('.modal-action')).toBeInTheDocument()
   })
 })

--- a/apps/web/src/components/ui/ConfirmDialog.tsx
+++ b/apps/web/src/components/ui/ConfirmDialog.tsx
@@ -26,7 +26,7 @@ export const ConfirmDialog = ({
     }}
   >
     <Dialog.Portal>
-      <Dialog.Overlay className='bg-opacity-50 fixed inset-0 bg-black' onClick={onCancel} />
+      <Dialog.Overlay className='fixed inset-0 bg-black/50' onClick={onCancel} />
       <Dialog.Content
         className='modal modal-open'
         onInteractOutside={event => event.preventDefault()}

--- a/apps/web/src/components/ui/ConfirmDialog.tsx
+++ b/apps/web/src/components/ui/ConfirmDialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useId } from 'react'
+import * as Dialog from '@radix-ui/react-dialog'
 
 import { Button } from './Button'
 
@@ -18,53 +18,32 @@ export const ConfirmDialog = ({
   cancelLabel = 'Annuler',
   onConfirm,
   onCancel
-}: ConfirmDialogProps) => {
-  const dialogId = useId()
-  const titleId = `${dialogId}-title`
-  const descriptionId = `${dialogId}-description`
-
-  useEffect(() => {
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') {
-        onCancel()
-      }
-    }
-
-    document.addEventListener('keydown', handleKeyDown)
-
-    return () => {
-      document.removeEventListener('keydown', handleKeyDown)
-    }
-  }, [onCancel])
-
-  return (
-    <div
-      className='fixed inset-0 z-50 flex items-center justify-center bg-zinc-950/70'
-      onClick={onCancel}
-    >
-      <section
-        className='max-w-md rounded-lg bg-zinc-800 p-6'
-        aria-labelledby={titleId}
-        aria-describedby={descriptionId}
-        role='dialog'
-        aria-modal='true'
-        onClick={event => event.stopPropagation()}
+}: ConfirmDialogProps) => (
+  <Dialog.Root
+    open={true}
+    onOpenChange={open => {
+      if (!open) onCancel()
+    }}
+  >
+    <Dialog.Portal>
+      <Dialog.Overlay className='bg-opacity-50 fixed inset-0 bg-black' onClick={onCancel} />
+      <Dialog.Content
+        className='modal modal-open'
+        onInteractOutside={event => event.preventDefault()}
       >
-        <h2 id={titleId} className='text-lg font-semibold'>
-          {title}
-        </h2>
-        <p id={descriptionId} className='mt-2 text-zinc-400'>
-          {message}
-        </p>
-        <div className='mt-6 flex justify-end gap-2'>
-          <Button onClick={onCancel} variant='outline'>
-            {cancelLabel}
-          </Button>
-          <Button onClick={onConfirm} variant='destructive'>
-            {confirmLabel}
-          </Button>
+        <div className='modal-box'>
+          <Dialog.Title className='text-lg font-bold'>{title}</Dialog.Title>
+          <Dialog.Description className='py-4'>{message}</Dialog.Description>
+          <div className='modal-action'>
+            <Button variant='outline' onClick={onCancel}>
+              {cancelLabel}
+            </Button>
+            <Button variant='destructive' onClick={onConfirm}>
+              {confirmLabel}
+            </Button>
+          </div>
         </div>
-      </section>
-    </div>
-  )
-}
+      </Dialog.Content>
+    </Dialog.Portal>
+  </Dialog.Root>
+)

--- a/apps/web/src/components/ui/FormWrapper.spec.tsx
+++ b/apps/web/src/components/ui/FormWrapper.spec.tsx
@@ -48,9 +48,7 @@ describe('FormWrapper', () => {
     )
 
     expect(screen.getByText(errorMessage)).toBeInTheDocument()
-    expect(screen.getByRole('alert')).toHaveClass(
-      'rounded-md bg-red-800/80 p-3 font-bold text-red-300'
-    )
+    expect(screen.getByRole('alert')).toHaveClass('alert alert-error')
   })
 
   it('should not display error message when error is null', () => {

--- a/apps/web/src/components/ui/FormWrapper.tsx
+++ b/apps/web/src/components/ui/FormWrapper.tsx
@@ -16,7 +16,7 @@ export const FormWrapper = ({
 }: FormWrapperProps) => (
   <form onSubmit={onSubmit} className={className} role='form'>
     {error && (
-      <p className='rounded-md bg-red-800/80 p-3 font-bold text-red-300' role='alert'>
+      <p className='alert alert-error' role='alert'>
         {error}
       </p>
     )}

--- a/apps/web/src/components/ui/Input.spec.tsx
+++ b/apps/web/src/components/ui/Input.spec.tsx
@@ -16,6 +16,7 @@ describe('Input', () => {
     const input = getByRole('textbox')
 
     expect(input).toBeInTheDocument()
+    expect(input).toHaveClass('input')
   })
 
   it('should render with a label when provided', () => {
@@ -48,6 +49,8 @@ describe('Input', () => {
     const errorMessage = getByText('Test Error')
 
     expect(errorMessage).toBeInTheDocument()
+    expect(errorMessage).toHaveClass('label')
+    expect(errorMessage).toHaveClass('text-error')
   })
 
   it('should set aria-invalid when error is present', () => {

--- a/apps/web/src/components/ui/Input.tsx
+++ b/apps/web/src/components/ui/Input.tsx
@@ -19,7 +19,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
     return (
       <div className={`${fullWidth ? 'w-full' : ''}`}>
         {label && (
-          <label htmlFor={inputId} className='flex font-medium text-zinc-300'>
+          <label htmlFor={inputId} className='flex font-medium'>
             {label}
           </label>
         )}

--- a/apps/web/src/components/ui/Input.tsx
+++ b/apps/web/src/components/ui/Input.tsx
@@ -12,9 +12,8 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
     const generatedId = useId()
     const inputId = id || `input-${generatedId}`
 
-    const baseInputClasses =
-      'rounded-lg border-2 bg-zinc-900 px-3 py-2 text-zinc-300 focus:outline-none'
-    const errorInputClasses = 'border-red-400 focus:border-red-400'
+    const baseInputClasses = 'input'
+    const errorInputClasses = 'input-error'
     const widthClass = fullWidth ? 'w-full' : ''
 
     return (
@@ -34,7 +33,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
           {...props}
         />
         {error && (
-          <p id={`${inputId}-error`} className='mt-2 font-semibold text-red-400'>
+          <p id={`${inputId}-error`} className='label text-error'>
             {error}
           </p>
         )}

--- a/apps/web/src/components/ui/Label.spec.tsx
+++ b/apps/web/src/components/ui/Label.spec.tsx
@@ -24,7 +24,6 @@ describe('Label', () => {
     const label = getByText('Test Label')
 
     expect(label).toHaveClass('font-medium')
-    expect(label).toHaveClass('text-zinc-300')
   })
 
   it('should show required indicator when required is true', () => {
@@ -35,6 +34,7 @@ describe('Label', () => {
 
     expect(label).toBeInTheDocument()
     expect(requiredIndicator).toBeInTheDocument()
+    expect(requiredIndicator).toHaveClass('text-error')
   })
 
   it('should not show required indicator when required is false', () => {

--- a/apps/web/src/components/ui/Label.tsx
+++ b/apps/web/src/components/ui/Label.tsx
@@ -8,13 +8,13 @@ export interface LabelProps extends LabelHTMLAttributes<HTMLLabelElement> {
 
 export const Label = React.forwardRef<HTMLLabelElement, LabelProps>(
   ({ children, className = '', required = false, ...props }, ref) => {
-    const baseClasses = 'flex font-medium text-zinc-300'
+    const baseClasses = 'flex font-medium'
     const combinedClasses = `${baseClasses} ${className}`
 
     return (
       <label ref={ref} className={combinedClasses} {...props}>
         {children}
-        {required && <span className='ml-1 text-red-400'>*</span>}
+        {required && <span className='text-error ml-1'>*</span>}
       </label>
     )
   }

--- a/apps/web/src/components/ui/Select.spec.tsx
+++ b/apps/web/src/components/ui/Select.spec.tsx
@@ -18,11 +18,16 @@ describe('Select', () => {
   })
 
   it('should render all options', () => {
-    const { getByText } = render(<Select options={mockOptions} placeholder='Select an option' />)
+    const { getByText, getByRole } = render(
+      <Select options={mockOptions} placeholder='Select an option' />
+    )
 
     mockOptions.forEach(option => {
       expect(getByText(option.label)).toBeInTheDocument()
     })
+
+    const select = getByRole('combobox')
+    expect(select).toHaveClass('select')
   })
 
   it('should render with a label when provided', () => {
@@ -76,6 +81,7 @@ describe('Select', () => {
     const select = getByRole('combobox')
 
     expect(select).toHaveAttribute('aria-invalid', 'true')
+    expect(select).toHaveClass('select-error')
   })
 
   it('should not set aria-invalid when no error is present', () => {

--- a/apps/web/src/components/ui/Select.tsx
+++ b/apps/web/src/components/ui/Select.tsx
@@ -22,14 +22,14 @@ export const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
     const generatedId = useId()
     const selectId = id || `select-${generatedId}`
 
-    const baseInputClasses = 'rounded-lg border-2 bg-zinc-900 px-3 py-2 text-zinc-300'
-    const errorInputClasses = 'border-red-400 focus:border-red-400'
+    const baseInputClasses = 'select'
+    const errorInputClasses = 'select-error'
     const widthClass = fullWidth ? 'w-full' : ''
 
     return (
       <div className={`${widthClass}`}>
         {label && (
-          <label htmlFor={selectId} className='flex font-medium text-zinc-300'>
+          <label htmlFor={selectId} className='flex font-medium'>
             {label}
           </label>
         )}
@@ -53,7 +53,7 @@ export const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
           ))}
         </select>
         {error && (
-          <p id={`${selectId}-error`} className='mt-2 font-semibold text-red-400'>
+          <p id={`${selectId}-error`} className='label text-error'>
             {error}
           </p>
         )}

--- a/apps/web/src/components/ui/Textarea.spec.tsx
+++ b/apps/web/src/components/ui/Textarea.spec.tsx
@@ -16,6 +16,7 @@ describe('Textarea', () => {
     const textarea = getByRole('textbox')
 
     expect(textarea).toBeInTheDocument()
+    expect(textarea).toHaveClass('textarea')
   })
 
   it('should render with a label when provided', () => {
@@ -32,6 +33,8 @@ describe('Textarea', () => {
     const errorMessage = getByText('This field is required')
 
     expect(errorMessage).toBeInTheDocument()
+    expect(errorMessage).toHaveClass('label')
+    expect(errorMessage).toHaveClass('text-error')
   })
 
   it('should set aria-invalid when error is present', () => {
@@ -40,6 +43,7 @@ describe('Textarea', () => {
     const textarea = getByRole('textbox')
 
     expect(textarea).toHaveAttribute('aria-invalid', 'true')
+    expect(textarea).toHaveClass('textarea-error')
   })
 
   it('should link error message via aria-describedby', () => {

--- a/apps/web/src/components/ui/Textarea.tsx
+++ b/apps/web/src/components/ui/Textarea.tsx
@@ -13,14 +13,14 @@ export const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
     const generatedId = useId()
     const textareaId = id || `textarea-${generatedId}`
     const errorId = `${textareaId}-error`
-    const baseClasses = 'rounded-lg border-2 bg-zinc-900 px-3 py-2 text-zinc-300 focus:outline-none'
-    const errorClasses = 'border-red-400 focus:border-red-400'
+    const baseClasses = 'textarea'
+    const errorClasses = 'textarea-error'
     const widthClass = fullWidth ? 'w-full' : ''
 
     return (
       <div className={`${widthClass}`}>
         {label && (
-          <label htmlFor={textareaId} className='flex font-medium text-zinc-300'>
+          <label htmlFor={textareaId} className='flex font-medium'>
             {label}
           </label>
         )}
@@ -34,7 +34,7 @@ export const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
           {...rest}
         />
         {error && (
-          <p id={errorId} className='mt-2 font-semibold text-red-400'>
+          <p id={errorId} className='label text-error'>
             {error}
           </p>
         )}

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -24,27 +24,27 @@
 
 ### Block 2: Shared UI Components (Phases 3-7) — `feature/design-system-ui-components`
 
-#### Phase 3: Button Component Migration
+#### Phase 3: Button Component Migration ✅
 
-- [ ] Button.tsx → DaisyUI btn classes + tests
+- [x] Button.tsx → DaisyUI btn classes + tests
 
-#### Phase 4: Input & Label Components
+#### Phase 4: Input & Label Components ✅
 
-- [ ] Input.tsx → DaisyUI input classes + tests
-- [ ] Label.tsx → DaisyUI label classes + tests
+- [x] Input.tsx → DaisyUI input classes + tests
+- [x] Label.tsx → DaisyUI label classes + tests
 
-#### Phase 5: Textarea & Select Components
+#### Phase 5: Textarea & Select Components ✅
 
-- [ ] Textarea.tsx → DaisyUI textarea classes + tests
-- [ ] Select.tsx → DaisyUI select classes + tests
+- [x] Textarea.tsx → DaisyUI textarea classes + tests
+- [x] Select.tsx → DaisyUI select classes + tests
 
-#### Phase 6: FormWrapper Migration
+#### Phase 6: FormWrapper Migration ✅
 
-- [ ] FormWrapper.tsx → DaisyUI alert for errors + tests
+- [x] FormWrapper.tsx → DaisyUI alert for errors + tests
 
-#### Phase 7: ConfirmDialog → Radix UI Dialog
+#### Phase 7: ConfirmDialog → Radix UI Dialog ✅
 
-- [ ] ConfirmDialog.tsx → Radix UI Dialog + DaisyUI modal + tests
+- [x] ConfirmDialog.tsx → Radix UI Dialog + DaisyUI modal + tests
 
 ---
 


### PR DESCRIPTION
## Summary

- Migrate 7 shared UI components from ad-hoc Tailwind classes to DaisyUI semantic classes
- Replace custom ConfirmDialog modal with Radix UI Dialog + DaisyUI modal styling
- All 514 tests passing, no functional behavior changes

## Components migrated

| Phase | Component | DaisyUI classes |
|-------|-----------|----------------|
| 3 | Button | btn, btn-primary/outline/ghost/error |
| 4 | Input | input, input-error |
| 4 | Label | flex font-medium, text-error |
| 5 | Textarea | textarea, textarea-error |
| 5 | Select | select, select-error |
| 6 | FormWrapper | alert alert-error |
| 7 | ConfirmDialog | Radix UI Dialog + modal-box, modal-action |

## Test plan

- [x] All 514 tests pass
- [x] Typecheck passes
- [x] Lint passes
- [x] Format passes
- [x] Manual visual review of components