### PR TITLE
feat(web): migrate auth components to DaisyUI design system

### DIFF
--- a/apps/web/src/features/auth/components/AuthContainer.tsx
+++ b/apps/web/src/features/auth/components/AuthContainer.tsx
@@ -68,13 +68,13 @@ export const AuthContainer = ({ mode = 'login', redirectPath }: AuthContainerPro
 
           <a
             href={routes.auth.getOppositeModeUrl('login')}
-            className='font-semibold text-amber-200 hover:text-amber-300'
+            className='link link-primary font-semibold'
           >
             Need an account?
           </a>
         </div>
         <div className='text-center'>
-          <a href='/auth/forgot-password' className='text-sm text-zinc-400 hover:text-zinc-300'>
+          <a href='/auth/forgot-password' className='link link-hover text-sm'>
             Forgot your password?
           </a>
         </div>
@@ -96,7 +96,7 @@ export const AuthContainer = ({ mode = 'login', redirectPath }: AuthContainerPro
 
         <a
           href={routes.auth.getOppositeModeUrl('signup')}
-          className='font-semibold text-amber-200 hover:text-amber-300'
+          className='link link-primary font-semibold'
         >
           Already have an account?
         </a>

--- a/apps/web/src/features/auth/components/ForgotPasswordContainer.tsx
+++ b/apps/web/src/features/auth/components/ForgotPasswordContainer.tsx
@@ -39,15 +39,17 @@ export const ForgotPasswordContainer = () => {
 
   if (status === 'success') {
     return (
-      <div className='mx-auto max-w-md rounded-lg bg-zinc-800/50 p-6 text-center'>
-        <h2 className='mb-4 text-2xl font-bold text-zinc-100'>Check Your Email</h2>
-        <p className='mb-6 text-zinc-300'>
-          If an account exists with that email, we've sent a password reset link.
-        </p>
-        <Button as='a' href='/auth?mode=login'>
-          Back to Login
-        </Button>
-      </div>
+      <section className='card bg-base-200 mx-auto max-w-md text-center'>
+        <div className='card-body'>
+          <h2 className='mb-4 text-2xl font-bold'>Check Your Email</h2>
+          <p className='text-base-content/70 mb-6'>
+            If an account exists with that email, we've sent a password reset link.
+          </p>
+          <Button as='a' href='/auth?mode=login'>
+            Back to Login
+          </Button>
+        </div>
+      </section>
     )
   }
 
@@ -65,7 +67,7 @@ export const ForgotPasswordContainer = () => {
         <Button type='submit' disabled={form.formState.isSubmitting}>
           {form.formState.isSubmitting ? 'Sending...' : 'Send Reset Link'}
         </Button>
-        <a href='/auth?mode=login' className='font-semibold text-amber-200 hover:text-amber-300'>
+        <a href='/auth?mode=login' className='link link-primary font-semibold'>
           Back to Login
         </a>
       </div>

--- a/apps/web/src/features/auth/components/ResetPasswordContainer.tsx
+++ b/apps/web/src/features/auth/components/ResetPasswordContainer.tsx
@@ -41,25 +41,31 @@ export const ResetPasswordContainer = ({ token }: ResetPasswordContainerProps) =
 
   if (!token) {
     return (
-      <div className='mx-auto max-w-md rounded-lg bg-zinc-800/50 p-6 text-center'>
-        <h2 className='mb-4 text-2xl font-bold text-red-400'>Invalid Reset Link</h2>
-        <p className='mb-6 text-zinc-300'>This password reset link is invalid or has expired.</p>
-        <Button as='a' href='/auth/forgot-password'>
-          Request New Link
-        </Button>
-      </div>
+      <section className='card bg-base-200 mx-auto max-w-md text-center'>
+        <div className='card-body'>
+          <h2 className='text-error mb-4 text-2xl font-bold'>Invalid Reset Link</h2>
+          <p className='text-base-content/70 mb-6'>
+            This password reset link is invalid or has expired.
+          </p>
+          <Button as='a' href='/auth/forgot-password'>
+            Request New Link
+          </Button>
+        </div>
+      </section>
     )
   }
 
   if (status === 'success') {
     return (
-      <div className='mx-auto max-w-md rounded-lg bg-zinc-800/50 p-6 text-center'>
-        <h2 className='mb-4 text-2xl font-bold text-zinc-100'>Password Reset</h2>
-        <p className='mb-6 text-zinc-300'>Your password has been successfully reset.</p>
-        <Button as='a' href='/auth?mode=login'>
-          Go to Login
-        </Button>
-      </div>
+      <section className='card bg-base-200 mx-auto max-w-md text-center'>
+        <div className='card-body'>
+          <h2 className='mb-4 text-2xl font-bold'>Password Reset</h2>
+          <p className='text-base-content/70 mb-6'>Your password has been successfully reset.</p>
+          <Button as='a' href='/auth?mode=login'>
+            Go to Login
+          </Button>
+        </div>
+      </section>
     )
   }
 
@@ -85,7 +91,7 @@ export const ResetPasswordContainer = ({ token }: ResetPasswordContainerProps) =
         <Button type='submit' disabled={form.formState.isSubmitting}>
           {form.formState.isSubmitting ? 'Resetting...' : 'Reset Password'}
         </Button>
-        <a href='/auth?mode=login' className='font-semibold text-amber-200 hover:text-amber-300'>
+        <a href='/auth?mode=login' className='link link-primary font-semibold'>
           Back to Login
         </a>
       </div>

--- a/apps/web/src/features/auth/components/SessionList.tsx
+++ b/apps/web/src/features/auth/components/SessionList.tsx
@@ -104,7 +104,11 @@ export const SessionList = () => {
           </div>
         </header>
 
-        {error && <p className='text-error mt-4'>{error}</p>}
+        {error && (
+          <p role='alert' className='text-error mt-4'>
+            {error}
+          </p>
+        )}
 
         {sessions.length === 0 ? (
           <p className='text-base-content/70 mt-4'>No active sessions found.</p>

--- a/apps/web/src/features/auth/components/SessionList.tsx
+++ b/apps/web/src/features/auth/components/SessionList.tsx
@@ -78,69 +78,73 @@ export const SessionList = () => {
 
   if (isLoading) {
     return (
-      <section className='rounded-lg bg-zinc-800 p-6'>
-        <h2 className='text-lg font-bold text-zinc-100'>Active Sessions</h2>
-        <p className='mt-4 text-zinc-400'>Loading sessions...</p>
+      <section className='card bg-base-200'>
+        <div className='card-body'>
+          <h2 className='text-lg font-bold'>Active Sessions</h2>
+          <p className='text-base-content/70 mt-4'>Loading sessions...</p>
+        </div>
       </section>
     )
   }
 
   return (
-    <section className='rounded-lg bg-zinc-800 p-6'>
-      <header className='flex items-center justify-between'>
-        <h2 className='text-lg font-bold text-zinc-100'>Active Sessions</h2>
-        <div className='flex gap-2'>
-          {sessions.length > 1 && (
-            <Button variant='outline' onClick={handleRevokeOtherSessions}>
-              Log out other devices
+    <section className='card bg-base-200'>
+      <div className='card-body'>
+        <header className='flex items-center justify-between'>
+          <h2 className='text-lg font-bold'>Active Sessions</h2>
+          <div className='flex gap-2'>
+            {sessions.length > 1 && (
+              <Button variant='outline' onClick={handleRevokeOtherSessions}>
+                Log out other devices
+              </Button>
+            )}
+            <Button variant='destructive' onClick={handleRevokeAllSessions}>
+              Log out everywhere
             </Button>
-          )}
-          <Button variant='destructive' onClick={handleRevokeAllSessions}>
-            Log out everywhere
-          </Button>
-        </div>
-      </header>
+          </div>
+        </header>
 
-      {error && <p className='mt-4 text-red-400'>{error}</p>}
+        {error && <p className='text-error mt-4'>{error}</p>}
 
-      {sessions.length === 0 ? (
-        <p className='mt-4 text-zinc-400'>No active sessions found.</p>
-      ) : (
-        <ul className='mt-4 space-y-3'>
-          {sessions.map(session => {
-            const isCurrent = session.token === currentToken
+        {sessions.length === 0 ? (
+          <p className='text-base-content/70 mt-4'>No active sessions found.</p>
+        ) : (
+          <ul className='mt-4 space-y-3'>
+            {sessions.map(session => {
+              const isCurrent = session.token === currentToken
 
-            return (
-              <li
-                key={session.id}
-                className={`flex items-center justify-between rounded-lg border p-4 ${
-                  isCurrent ? 'border-sky-400 bg-zinc-700' : 'border-zinc-700'
-                }`}
-              >
-                <div>
-                  <p className='text-zinc-100'>
-                    {session.userAgent ?? 'Unknown device'}
-                    {isCurrent && (
-                      <span className='ml-2 rounded bg-sky-400 px-2 py-0.5 text-xs font-medium text-zinc-900'>
-                        Current
-                      </span>
-                    )}
-                  </p>
-                  <p className='text-sm text-zinc-400'>
-                    {session.ipAddress ?? 'Unknown IP'} · Created{' '}
-                    {new Date(session.createdAt).toLocaleDateString()}
-                  </p>
-                </div>
-                {!isCurrent && (
-                  <Button variant='ghost' onClick={() => handleRevokeSession(session.token)}>
-                    Revoke
-                  </Button>
-                )}
-              </li>
-            )
-          })}
-        </ul>
-      )}
+              return (
+                <li
+                  key={session.id}
+                  className={`flex items-center justify-between rounded-lg border p-4 ${
+                    isCurrent ? 'border-primary bg-base-300' : 'border-base-content/20'
+                  }`}
+                >
+                  <div>
+                    <p>
+                      {session.userAgent ?? 'Unknown device'}
+                      {isCurrent && <span className='badge badge-primary ml-2'>Current</span>}
+                    </p>
+                    <p className='text-base-content/70 text-sm'>
+                      {session.ipAddress ?? 'Unknown IP'} · Created{' '}
+                      {new Date(session.createdAt).toLocaleDateString()}
+                    </p>
+                  </div>
+                  {!isCurrent && (
+                    <Button
+                      variant='ghost'
+                      className='border-base-content/20 border'
+                      onClick={() => handleRevokeSession(session.token)}
+                    >
+                      Revoke
+                    </Button>
+                  )}
+                </li>
+              )
+            })}
+          </ul>
+        )}
+      </div>
     </section>
   )
 }

--- a/apps/web/src/features/auth/components/VerificationPendingContainer.tsx
+++ b/apps/web/src/features/auth/components/VerificationPendingContainer.tsx
@@ -33,35 +33,33 @@ export const VerificationPendingContainer = ({ email }: VerificationPendingConta
   }
 
   return (
-    <div className='mx-auto max-w-md rounded-lg bg-zinc-800/50 p-6 text-center'>
-      <h2 className='mb-4 text-2xl font-bold text-zinc-100'>Check Your Email</h2>
-      <p className='mb-6 text-zinc-300'>
-        We sent a verification link to{' '}
-        <strong className='text-amber-200'>{email ?? 'your email'}</strong>. Please check your inbox
-        and click the link to verify your account.
-      </p>
-
-      {resendStatus === 'success' && (
-        <p className='mb-4 rounded-md bg-green-900/50 p-3 text-green-400'>
-          Verification email sent! Check your inbox.
+    <section className='card bg-base-200 mx-auto max-w-md text-center'>
+      <div className='card-body'>
+        <h2 className='mb-4 text-2xl font-bold'>Check Your Email</h2>
+        <p className='text-base-content/70 mb-6'>
+          We sent a verification link to{' '}
+          <strong className='text-primary'>{email ?? 'your email'}</strong>. Please check your inbox
+          and click the link to verify your account.
         </p>
-      )}
 
-      {resendStatus === 'error' && (
-        <p className='mb-4 rounded-md bg-red-900/50 p-3 text-red-400'>{errorMessage}</p>
-      )}
-
-      <div className='flex flex-col gap-3'>
-        {email && (
-          <Button onClick={handleResend} disabled={isResending} variant='outline'>
-            {isResending ? 'Sending...' : 'Resend Verification Email'}
-          </Button>
+        {resendStatus === 'success' && (
+          <p className='alert alert-success mb-4'>Verification email sent! Check your inbox.</p>
         )}
 
-        <Button as='a' href='/auth?mode=login' variant='ghost'>
-          Back to Login
-        </Button>
+        {resendStatus === 'error' && <p className='alert alert-error mb-4'>{errorMessage}</p>}
+
+        <div className='flex flex-col gap-3'>
+          {email && (
+            <Button onClick={handleResend} disabled={isResending} variant='outline'>
+              {isResending ? 'Sending...' : 'Resend Verification Email'}
+            </Button>
+          )}
+
+          <Button as='a' href='/auth?mode=login' variant='ghost'>
+            Back to Login
+          </Button>
+        </div>
       </div>
-    </div>
+    </section>
   )
 }

--- a/apps/web/src/features/auth/components/VerificationPendingContainer.tsx
+++ b/apps/web/src/features/auth/components/VerificationPendingContainer.tsx
@@ -43,10 +43,16 @@ export const VerificationPendingContainer = ({ email }: VerificationPendingConta
         </p>
 
         {resendStatus === 'success' && (
-          <p className='alert alert-success mb-4'>Verification email sent! Check your inbox.</p>
+          <p role='status' className='alert alert-success mb-4'>
+            Verification email sent! Check your inbox.
+          </p>
         )}
 
-        {resendStatus === 'error' && <p className='alert alert-error mb-4'>{errorMessage}</p>}
+        {resendStatus === 'error' && (
+          <p role='alert' className='alert alert-error mb-4'>
+            {errorMessage}
+          </p>
+        )}
 
         <div className='flex flex-col gap-3'>
           {email && (

--- a/apps/web/src/features/auth/components/VerifyEmailContainer.tsx
+++ b/apps/web/src/features/auth/components/VerifyEmailContainer.tsx
@@ -34,46 +34,52 @@ export const VerifyEmailContainer = ({ token }: VerifyEmailContainerProps) => {
   if (status === 'verifying') {
     return (
       <div className='mx-auto max-w-md text-center'>
-        <p className='text-lg text-zinc-300'>Verifying your email...</p>
+        <p className='text-base-content/70 text-lg'>Verifying your email...</p>
       </div>
     )
   }
 
   if (status === 'success') {
     return (
-      <div className='mx-auto max-w-md rounded-lg bg-green-900/50 p-6 text-center'>
-        <h2 className='mb-4 text-2xl font-bold text-green-400'>Email Verified!</h2>
-        <p className='mb-6 text-zinc-300'>
-          Your email has been successfully verified. You can now log in to your account.
-        </p>
-        <Button as='a' href='/auth?mode=login'>
-          Go to Login
-        </Button>
-      </div>
+      <section className='card bg-base-200 mx-auto max-w-md text-center'>
+        <div className='card-body'>
+          <h2 className='text-success mb-4 text-2xl font-bold'>Email Verified!</h2>
+          <p className='text-base-content/70 mb-6'>
+            Your email has been successfully verified. You can now log in to your account.
+          </p>
+          <Button as='a' href='/auth?mode=login'>
+            Go to Login
+          </Button>
+        </div>
+      </section>
     )
   }
 
   if (status === 'error') {
     return (
-      <div className='mx-auto max-w-md rounded-lg bg-red-900/50 p-6 text-center'>
-        <h2 className='mb-4 text-2xl font-bold text-red-400'>Verification Failed</h2>
-        <p className='mb-6 text-zinc-300'>{errorMessage}</p>
-        <Button as='a' href='/auth/verification-pending'>
-          Request New Link
-        </Button>
-      </div>
+      <section className='card bg-base-200 mx-auto max-w-md text-center'>
+        <div className='card-body'>
+          <h2 className='text-error mb-4 text-2xl font-bold'>Verification Failed</h2>
+          <p className='text-base-content/70 mb-6'>{errorMessage}</p>
+          <Button as='a' href='/auth/verification-pending'>
+            Request New Link
+          </Button>
+        </div>
+      </section>
     )
   }
 
   return (
-    <div className='mx-auto max-w-md rounded-lg bg-yellow-900/50 p-6 text-center'>
-      <h2 className='mb-4 text-2xl font-bold text-yellow-400'>Invalid Link</h2>
-      <p className='mb-6 text-zinc-300'>
-        This verification link is invalid. Please check your email for the correct link.
-      </p>
-      <Button as='a' href='/auth?mode=login'>
-        Go to Login
-      </Button>
-    </div>
+    <section className='card bg-base-200 mx-auto max-w-md text-center'>
+      <div className='card-body'>
+        <h2 className='text-warning mb-4 text-2xl font-bold'>Invalid Link</h2>
+        <p className='text-base-content/70 mb-6'>
+          This verification link is invalid. Please check your email for the correct link.
+        </p>
+        <Button as='a' href='/auth?mode=login'>
+          Go to Login
+        </Button>
+      </div>
+    </section>
   )
 }

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -57,21 +57,21 @@
 
 ---
 
-### Block 4: Auth Feature (Phases 9-10) — `feature/design-system-auth`
+### Block 4: Auth Feature (Phases 9-10) — `feature/design-system-auth` ✅
 
-#### Phase 9: Auth Feature — Login & Signup
+#### Phase 9: Auth Feature — Login & Signup ✅
 
-- [ ] LoginForm.tsx + tests
-- [ ] SignupForm.tsx + tests
+- [x] LoginForm.tsx + tests (no changes needed — uses shared Input)
+- [x] SignupForm.tsx + tests (no changes needed — uses shared Input)
 
-#### Phase 10: Auth Feature — Remaining Screens
+#### Phase 10: Auth Feature — Remaining Screens ✅
 
-- [ ] AuthContainer.tsx + tests
-- [ ] ForgotPasswordContainer.tsx + tests
-- [ ] ResetPasswordContainer.tsx + tests
-- [ ] VerifyEmailContainer.tsx + tests
-- [ ] VerificationPendingContainer.tsx + tests
-- [ ] SessionList.tsx + tests
+- [x] AuthContainer.tsx + tests
+- [x] ForgotPasswordContainer.tsx + tests
+- [x] ResetPasswordContainer.tsx + tests
+- [x] VerifyEmailContainer.tsx + tests
+- [x] VerificationPendingContainer.tsx + tests
+- [x] SessionList.tsx + tests
 
 ---
 


### PR DESCRIPTION
## Summary

- Migrate 6 auth feature components from hardcoded Tailwind utility classes to DaisyUI semantic classes
- Replace `bg-zinc-800/50` card wrappers with `card bg-base-200` + `card-body` using semantic `<section>` elements
- Replace hardcoded link colors (`text-amber-200`) with `link link-primary`
- Replace hardcoded status colors with semantic classes (`text-error`, `text-success`, `text-warning`)
- Replace inline alert styles with `alert alert-success` / `alert alert-error`
- Replace custom session badge with `badge badge-primary`
- Fix WCAG contrast issues: `text-base-content/70` for secondary text, `border-base-content/20` for visible borders
- LoginForm and SignupForm needed no changes (already use shared Input migrated in Block 2)

## Components migrated

| Component | Key changes |
|-----------|------------|
| AuthContainer | `link link-primary`, `link link-hover` |
| ForgotPasswordContainer | `card`/`card-body`, `link-primary` |
| ResetPasswordContainer | `card`/`card-body`, `text-error` |
| VerifyEmailContainer | `card`/`card-body`, `text-success`/`text-error`/`text-warning` |
| VerificationPendingContainer | `card`/`card-body`, `alert` classes |
| SessionList | `card`/`card-body`, `badge-primary`, border/contrast fixes |

## Test plan

- [x] All 515 web tests pass (no test changes needed — tests are behavioral)
- [x] All 346 API tests pass (no regressions)
- [x] TypeScript compiles clean
- [x] ESLint passes
- [x] Prettier passes
- [x] Visual verification of auth screens in browser
- [x] WCAG contrast verified via Firefox accessibility panel