### PR TITLE
feat(check-logging): add database model and domain layer (Block 1)

### DIFF
--- a/apps/api/prisma/migrations/20260325160618_add_check_log/migration.sql
+++ b/apps/api/prisma/migrations/20260325160618_add_check_log/migration.sql
@@ -1,0 +1,14 @@
+-- CreateTable
+CREATE TABLE "CheckLog" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "checkTypeId" TEXT NOT NULL,
+    "completedAt" TEXT NOT NULL,
+    "notes" TEXT,
+    "nextDueAt" TEXT NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "CheckLog_checkTypeId_fkey" FOREIGN KEY ("checkTypeId") REFERENCES "CheckType" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateIndex
+CREATE INDEX "CheckLog_checkTypeId_idx" ON "CheckLog"("checkTypeId");

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -118,8 +118,23 @@ model CheckType {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
-  vehicle Vehicle @relation(fields: [vehicleId], references: [id], onDelete: Cascade)
+  vehicle   Vehicle    @relation(fields: [vehicleId], references: [id], onDelete: Cascade)
+  checkLogs CheckLog[]
 
   @@unique([vehicleId, name])
   @@index([vehicleId])
+}
+
+model CheckLog {
+  id          String   @id @default(uuid())
+  checkTypeId String
+  completedAt String
+  notes       String?
+  nextDueAt   String
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  checkType CheckType @relation(fields: [checkTypeId], references: [id], onDelete: Cascade)
+
+  @@index([checkTypeId])
 }

--- a/apps/api/src/check-logs/domain/entities/CheckLog.entity.spec.ts
+++ b/apps/api/src/check-logs/domain/entities/CheckLog.entity.spec.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'bun:test'
+
+import { CHECK_LOG_VALIDATION } from '../validation'
+import { CheckLogIdValueObject, CompletedAtValueObject } from '../value-objects'
+
+import { CheckLogEntity } from './CheckLog.entity'
+
+describe('CheckLogEntity', () => {
+  const defaultProps = {
+    id: new CheckLogIdValueObject('550e8400-e29b-41d4-a716-446655440000'),
+    checkTypeId: '660e8400-e29b-41d4-a716-446655440000',
+    completedAt: new CompletedAtValueObject('2026-03-15'),
+    notes: 'All good',
+    nextDueAt: '2026-03-22',
+    createdAt: new Date(),
+    updatedAt: new Date()
+  }
+
+  it('should create a valid entity with all fields', () => {
+    const entity = new CheckLogEntity(
+      defaultProps.id,
+      defaultProps.checkTypeId,
+      defaultProps.completedAt,
+      defaultProps.notes,
+      defaultProps.nextDueAt,
+      defaultProps.createdAt,
+      defaultProps.updatedAt
+    )
+
+    expect(entity).toBeInstanceOf(CheckLogEntity)
+    expect(entity.id).toBe(defaultProps.id)
+    expect(entity.checkTypeId).toBe(defaultProps.checkTypeId)
+    expect(entity.completedAt).toBe(defaultProps.completedAt)
+    expect(entity.notes).toBe(defaultProps.notes)
+    expect(entity.nextDueAt).toBe(defaultProps.nextDueAt)
+    expect(entity.createdAt).toBe(defaultProps.createdAt)
+    expect(entity.updatedAt).toBe(defaultProps.updatedAt)
+  })
+
+  it('should create a valid entity with null notes', () => {
+    const entity = new CheckLogEntity(
+      defaultProps.id,
+      defaultProps.checkTypeId,
+      defaultProps.completedAt,
+      null, // notes is null
+      defaultProps.nextDueAt,
+      defaultProps.createdAt,
+      defaultProps.updatedAt
+    )
+
+    expect(entity).toBeInstanceOf(CheckLogEntity)
+    expect(entity.notes).toBeNull()
+  })
+
+  it('should reject notes exceeding max length', () => {
+    const longNotes = 'a'.repeat(CHECK_LOG_VALIDATION.NOTES.MAX_LENGTH + 1)
+
+    expect(() => {
+      new CheckLogEntity(
+        defaultProps.id,
+        defaultProps.checkTypeId,
+        defaultProps.completedAt,
+        longNotes, // Exceeds max length
+        defaultProps.nextDueAt,
+        defaultProps.createdAt,
+        defaultProps.updatedAt
+      )
+    }).toThrow(`Notes cannot exceed ${CHECK_LOG_VALIDATION.NOTES.MAX_LENGTH} characters`)
+  })
+
+  it('should have all properties readonly (no update method)', () => {
+    const entity = new CheckLogEntity(
+      defaultProps.id,
+      defaultProps.checkTypeId,
+      defaultProps.completedAt,
+      defaultProps.notes,
+      defaultProps.nextDueAt,
+      defaultProps.createdAt,
+      defaultProps.updatedAt
+    )
+
+    expect(entity).toBeInstanceOf(CheckLogEntity)
+    expect(entity.id).toBe(defaultProps.id)
+    expect(entity.checkTypeId).toBe(defaultProps.checkTypeId)
+    expect(entity.completedAt).toBe(defaultProps.completedAt)
+    expect(entity.notes).toBe(defaultProps.notes)
+    expect(entity.nextDueAt).toBe(defaultProps.nextDueAt)
+    expect(entity.createdAt).toBe(defaultProps.createdAt)
+    expect(entity.updatedAt).toBe(defaultProps.updatedAt)
+
+    // Verify no update methods exist (this is more of a TypeScript compile-time check, but we can at least verify no methods are present)
+    const entityKeys = Object.keys(entity)
+    expect(entityKeys).toEqual(
+      expect.arrayContaining([
+        'id',
+        'checkTypeId',
+        'completedAt',
+        'notes',
+        'nextDueAt',
+        'createdAt',
+        'updatedAt'
+      ])
+    )
+    const entityMethods = Object.getOwnPropertyNames(Object.getPrototypeOf(entity)).filter(
+      prop =>
+        typeof (entity as unknown as Record<string, unknown>)[prop] === 'function' &&
+        prop !== 'constructor'
+    )
+    expect(entityMethods).toEqual([])
+  })
+})

--- a/apps/api/src/check-logs/domain/entities/CheckLog.entity.ts
+++ b/apps/api/src/check-logs/domain/entities/CheckLog.entity.ts
@@ -1,0 +1,21 @@
+import { InvalidCheckLogException } from '../exceptions'
+import { CHECK_LOG_VALIDATION } from '../validation'
+import type { CheckLogIdValueObject, CompletedAtValueObject } from '../value-objects'
+
+export class CheckLogEntity {
+  constructor(
+    public readonly id: CheckLogIdValueObject,
+    public readonly checkTypeId: string,
+    public readonly completedAt: CompletedAtValueObject,
+    public readonly notes: string | null,
+    public readonly nextDueAt: string,
+    public readonly createdAt: Date,
+    public readonly updatedAt: Date
+  ) {
+    if (notes && notes.length > CHECK_LOG_VALIDATION.NOTES.MAX_LENGTH) {
+      throw new InvalidCheckLogException(
+        `Notes cannot exceed ${CHECK_LOG_VALIDATION.NOTES.MAX_LENGTH} characters`
+      )
+    }
+  }
+}

--- a/apps/api/src/check-logs/domain/entities/index.ts
+++ b/apps/api/src/check-logs/domain/entities/index.ts
@@ -1,0 +1,1 @@
+export { CheckLogEntity } from './CheckLog.entity'

--- a/apps/api/src/check-logs/domain/exceptions/CheckLogNotFound.exception.ts
+++ b/apps/api/src/check-logs/domain/exceptions/CheckLogNotFound.exception.ts
@@ -1,0 +1,9 @@
+/**
+ * @description Thrown when attempting to access a check log that does not exist.
+ */
+export class CheckLogNotFoundException extends Error {
+  constructor(identifier?: string) {
+    super(identifier ? `Check log not found: ${identifier}` : 'Check log not found')
+    this.name = 'CheckLogNotFoundException'
+  }
+}

--- a/apps/api/src/check-logs/domain/exceptions/InvalidCheckLog.exception.ts
+++ b/apps/api/src/check-logs/domain/exceptions/InvalidCheckLog.exception.ts
@@ -1,0 +1,9 @@
+/**
+ * @description Thrown when attempting to perform an operation on an invalid check log.
+ */
+export class InvalidCheckLogException extends Error {
+  constructor(message?: string) {
+    super(message ?? 'Invalid check log')
+    this.name = 'InvalidCheckLogException'
+  }
+}

--- a/apps/api/src/check-logs/domain/exceptions/index.ts
+++ b/apps/api/src/check-logs/domain/exceptions/index.ts
@@ -1,0 +1,2 @@
+export { CheckLogNotFoundException } from './CheckLogNotFound.exception'
+export { InvalidCheckLogException } from './InvalidCheckLog.exception'

--- a/apps/api/src/check-logs/domain/repositories/ICheckLog.repository.ts
+++ b/apps/api/src/check-logs/domain/repositories/ICheckLog.repository.ts
@@ -1,0 +1,11 @@
+import type { CheckLogEntity } from '../entities'
+import type { CheckLogIdValueObject } from '../value-objects'
+
+export interface ICheckLogRepository {
+  create(checkLog: CheckLogEntity): Promise<CheckLogEntity>
+  findById(id: CheckLogIdValueObject): Promise<CheckLogEntity | null>
+  findByCheckTypeId(checkTypeId: string): Promise<CheckLogEntity[]>
+  findByVehicleId(vehicleId: string): Promise<CheckLogEntity[]>
+  findMostRecentByCheckTypeIds(checkTypeIds: string[]): Promise<Map<string, CheckLogEntity>>
+  delete(id: CheckLogIdValueObject): Promise<void>
+}

--- a/apps/api/src/check-logs/domain/repositories/index.ts
+++ b/apps/api/src/check-logs/domain/repositories/index.ts
@@ -1,0 +1,1 @@
+export type { ICheckLogRepository } from './ICheckLog.repository'

--- a/apps/api/src/check-logs/domain/validation/CheckLog.validation.ts
+++ b/apps/api/src/check-logs/domain/validation/CheckLog.validation.ts
@@ -1,0 +1,11 @@
+export const CHECK_LOG_VALIDATION = {
+  NOTES: {
+    MAX_LENGTH: 500,
+    MESSAGE: 'Notes must not exceed 500 characters'
+  },
+  COMPLETED_AT: {
+    PATTERN: /^\d{4}-\d{2}-\d{2}$/,
+    MESSAGE: 'Completed date must be in YYYY-MM-DD format',
+    FUTURE_MESSAGE: 'Completed date cannot be in the future'
+  }
+} as const

--- a/apps/api/src/check-logs/domain/validation/index.ts
+++ b/apps/api/src/check-logs/domain/validation/index.ts
@@ -1,0 +1,1 @@
+export { CHECK_LOG_VALIDATION } from './CheckLog.validation'

--- a/apps/api/src/check-logs/domain/value-objects/CheckLogId.vo.spec.ts
+++ b/apps/api/src/check-logs/domain/value-objects/CheckLogId.vo.spec.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'bun:test'
+
+import { CheckLogIdValueObject } from './CheckLogId.vo'
+
+describe('CheckLogIdValueObject', () => {
+  const validUuid = '550e8400-e29b-41d4-a716-446655440000'
+
+  describe('constructor', () => {
+    it('should create a valid CheckLogId from a non-empty string', () => {
+      const checkLogId = new CheckLogIdValueObject(validUuid)
+
+      expect(checkLogId.value).toBe(validUuid)
+    })
+
+    it('should throw an error for an empty string', () => {
+      expect(() => new CheckLogIdValueObject('')).toThrow('CheckLogId must be a non-empty string')
+    })
+
+    it('should throw an error for a whitespace-only string', () => {
+      expect(() => new CheckLogIdValueObject('   ')).toThrow(
+        'CheckLogId must be a non-empty string'
+      )
+    })
+
+    it('should throw an error for invalid UUID format', () => {
+      expect(() => new CheckLogIdValueObject('invalid-uuid')).toThrow(
+        'CheckLogId must be a valid UUID'
+      )
+    })
+  })
+
+  describe('generate', () => {
+    it('should generate a unique CheckLogId', () => {
+      const id1 = CheckLogIdValueObject.generate()
+      const id2 = CheckLogIdValueObject.generate()
+
+      expect(id1).toBeInstanceOf(CheckLogIdValueObject)
+      expect(id2).toBeInstanceOf(CheckLogIdValueObject)
+      expect(id1.value).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i)
+      expect(id2.value).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i)
+      expect(id1.value).not.toBe(id2.value)
+    })
+  })
+
+  describe('equals', () => {
+    it('should return true for equal values', () => {
+      const id1 = new CheckLogIdValueObject(validUuid)
+      const id2 = new CheckLogIdValueObject(validUuid)
+
+      expect(id1.equals(id2)).toBe(true)
+    })
+
+    it('should return false for different values', () => {
+      const id1 = new CheckLogIdValueObject(validUuid)
+      const id2 = new CheckLogIdValueObject('550e8400-e29b-41d4-a716-446655440001')
+
+      expect(id1.equals(id2)).toBe(false)
+    })
+  })
+
+  describe('toString', () => {
+    it('should return the string value', () => {
+      const id = new CheckLogIdValueObject(validUuid)
+
+      expect(id.toString()).toBe(validUuid)
+    })
+  })
+})

--- a/apps/api/src/check-logs/domain/value-objects/CheckLogId.vo.ts
+++ b/apps/api/src/check-logs/domain/value-objects/CheckLogId.vo.ts
@@ -1,0 +1,39 @@
+import { randomUUID } from 'crypto'
+
+export class CheckLogIdValueObject {
+  private readonly _value: string
+
+  constructor(value: string) {
+    if (!value || typeof value !== 'string' || value.trim() === '') {
+      throw new Error('CheckLogId must be a non-empty string')
+    }
+
+    if (!this.isValidCheckLogIdFormat(value)) {
+      throw new Error('CheckLogId must be a valid UUID')
+    }
+
+    this._value = value
+  }
+
+  static generate(): CheckLogIdValueObject {
+    return new CheckLogIdValueObject(randomUUID())
+  }
+
+  get value(): string {
+    return this._value
+  }
+
+  equals(other: CheckLogIdValueObject): boolean {
+    return this._value === other._value
+  }
+
+  toString(): string {
+    return this._value
+  }
+
+  private isValidCheckLogIdFormat(value: string): boolean {
+    const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+    return uuidRegex.test(value)
+  }
+}

--- a/apps/api/src/check-logs/domain/value-objects/CompletedAt.vo.spec.ts
+++ b/apps/api/src/check-logs/domain/value-objects/CompletedAt.vo.spec.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'bun:test'
+
+import { CHECK_LOG_VALIDATION } from '../validation'
+
+import { CompletedAtValueObject } from './CompletedAt.vo'
+
+describe('CompletedAtValueObject', () => {
+  describe('constructor', () => {
+    it('should create from a valid YYYY-MM-DD string', () => {
+      const completedAt = new CompletedAtValueObject('2026-03-15')
+
+      expect(completedAt.value).toBe('2026-03-15')
+    })
+
+    it('should accept today as a valid date', () => {
+      const today = new Date().toISOString().split('T')[0]
+      const completedAt = new CompletedAtValueObject(today)
+
+      expect(completedAt.value).toBe(today)
+    })
+
+    it('should accept a past date', () => {
+      const completedAt = new CompletedAtValueObject('2020-01-01')
+
+      expect(completedAt.value).toBe('2020-01-01')
+    })
+
+    it('should reject invalid format (DD/MM/YYYY)', () => {
+      expect(() => new CompletedAtValueObject('15/06/2025')).toThrow(
+        CHECK_LOG_VALIDATION.COMPLETED_AT.MESSAGE
+      )
+    })
+
+    it('should reject invalid format (missing day)', () => {
+      expect(() => new CompletedAtValueObject('2025-06')).toThrow(
+        CHECK_LOG_VALIDATION.COMPLETED_AT.MESSAGE
+      )
+    })
+
+    it('should reject invalid date values (month 99)', () => {
+      expect(() => new CompletedAtValueObject('2025-99-01')).toThrow(
+        CHECK_LOG_VALIDATION.COMPLETED_AT.MESSAGE
+      )
+    })
+
+    it('should reject a future date', () => {
+      expect(() => new CompletedAtValueObject('2099-01-01')).toThrow(
+        CHECK_LOG_VALIDATION.COMPLETED_AT.FUTURE_MESSAGE
+      )
+    })
+  })
+
+  describe('value', () => {
+    it('should return the original YYYY-MM-DD string', () => {
+      const completedAt = new CompletedAtValueObject('2026-03-15')
+
+      expect(completedAt.value).toBe('2026-03-15')
+    })
+  })
+
+  describe('toDate', () => {
+    it('should return a Date at UTC midnight', () => {
+      const completedAt = new CompletedAtValueObject('2026-03-15')
+      const date = completedAt.toDate()
+
+      expect(date.getUTCHours()).toBe(0)
+      expect(date.getUTCMinutes()).toBe(0)
+      expect(date.getUTCSeconds()).toBe(0)
+      expect(date.getUTCFullYear()).toBe(2026)
+      expect(date.getUTCMonth()).toBe(2) // Months are 0-indexed
+      expect(date.getUTCDate()).toBe(15)
+    })
+  })
+
+  describe('equals', () => {
+    it('should return true for same date string', () => {
+      const completedAt1 = new CompletedAtValueObject('2026-03-15')
+      const completedAt2 = new CompletedAtValueObject('2026-03-15')
+
+      expect(completedAt1.equals(completedAt2)).toBe(true)
+    })
+
+    it('should return false for different date strings', () => {
+      const completedAt1 = new CompletedAtValueObject('2026-03-15')
+      const completedAt2 = new CompletedAtValueObject('2025-12-01')
+
+      expect(completedAt1.equals(completedAt2)).toBe(false)
+    })
+  })
+})

--- a/apps/api/src/check-logs/domain/value-objects/CompletedAt.vo.ts
+++ b/apps/api/src/check-logs/domain/value-objects/CompletedAt.vo.ts
@@ -1,0 +1,42 @@
+import { CHECK_LOG_VALIDATION } from '../validation'
+
+export class CompletedAtValueObject {
+  private readonly _value: string
+
+  constructor(value: string) {
+    if (!CHECK_LOG_VALIDATION.COMPLETED_AT.PATTERN.test(value)) {
+      throw new Error(CHECK_LOG_VALIDATION.COMPLETED_AT.MESSAGE)
+    }
+
+    const timestamp = Date.parse(value)
+
+    if (isNaN(timestamp)) {
+      throw new Error(CHECK_LOG_VALIDATION.COMPLETED_AT.MESSAGE)
+    }
+
+    const today = new Date()
+    today.setUTCHours(0, 0, 0, 0)
+    const input = new Date(value + 'T00:00:00Z')
+    if (input > today) {
+      throw new Error(CHECK_LOG_VALIDATION.COMPLETED_AT.FUTURE_MESSAGE)
+    }
+
+    this._value = value
+  }
+
+  get value(): string {
+    return this._value
+  }
+
+  toDate(): Date {
+    return new Date(this._value + 'T00:00:00Z')
+  }
+
+  equals(other: CompletedAtValueObject): boolean {
+    return this._value === other._value
+  }
+
+  toString(): string {
+    return this._value
+  }
+}

--- a/apps/api/src/check-logs/domain/value-objects/index.ts
+++ b/apps/api/src/check-logs/domain/value-objects/index.ts
@@ -1,0 +1,2 @@
+export { CheckLogIdValueObject } from './CheckLogId.vo'
+export { CompletedAtValueObject } from './CompletedAt.vo'

--- a/apps/web/src/features/check-logs/schemas/checkLog.schema.spec.ts
+++ b/apps/web/src/features/check-logs/schemas/checkLog.schema.spec.ts
@@ -35,6 +35,17 @@ describe('createCheckLogSchema', () => {
     )
   })
 
+  it('should reject invalid calendar date', () => {
+    const invalidData = { completedAt: '2020-99-99' }
+
+    const result = createCheckLogSchema.safeParse(invalidData)
+
+    expect(result.success).toBe(false)
+    expect(result.error?.issues[0].message).toBe(
+      `Le champ 'completedAt' doit être une date valide.`
+    )
+  })
+
   it('should reject future date', () => {
     const invalidData = { completedAt: '2099-01-01' }
 

--- a/apps/web/src/features/check-logs/schemas/checkLog.schema.spec.ts
+++ b/apps/web/src/features/check-logs/schemas/checkLog.schema.spec.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'bun:test'
+
+import { createCheckLogSchema } from './checkLog.schema'
+
+describe('createCheckLogSchema', () => {
+  it('should validate with valid completedAt and notes', () => {
+    const result = createCheckLogSchema.parse({ completedAt: '2026-03-15', notes: 'Tout est OK' })
+
+    expect(result).toEqual({ completedAt: '2026-03-15', notes: 'Tout est OK' })
+  })
+
+  it('should validate with only completedAt (notes optional)', () => {
+    const result = createCheckLogSchema.parse({ completedAt: '2026-03-15' })
+
+    expect(result).toEqual({ completedAt: '2026-03-15' })
+  })
+
+  it('should reject missing completedAt', () => {
+    const invalidData = {}
+
+    const result = createCheckLogSchema.safeParse(invalidData)
+
+    expect(result.success).toBe(false)
+    expect(result.error?.issues[0].message).toBe(`Le champ 'completedAt' est requis.`)
+  })
+
+  it('should reject invalid date format', () => {
+    const invalidData = { completedAt: '15/06/2025' }
+
+    const result = createCheckLogSchema.safeParse(invalidData)
+
+    expect(result.success).toBe(false)
+    expect(result.error?.issues[0].message).toBe(
+      `Le champ 'completedAt' doit être une date au format YYYY-MM-DD.`
+    )
+  })
+
+  it('should reject future date', () => {
+    const invalidData = { completedAt: '2099-01-01' }
+
+    const result = createCheckLogSchema.safeParse(invalidData)
+
+    expect(result.success).toBe(false)
+    expect(result.error?.issues[0].message).toBe(
+      `Le champ 'completedAt' ne peut pas être une date future.`
+    )
+  })
+
+  it('should accept today as completedAt', () => {
+    const today = new Date().toISOString().split('T')[0]
+    const result = createCheckLogSchema.safeParse({ completedAt: today })
+
+    expect(result.success).toBe(true)
+  })
+
+  it('should accept past date as completedAt', () => {
+    const pastDate = '2020-01-01'
+    const result = createCheckLogSchema.safeParse({ completedAt: pastDate })
+
+    expect(result.success).toBe(true)
+  })
+
+  it('should reject notes longer than 500 characters', () => {
+    const longNotes = 'a'.repeat(501)
+    const result = createCheckLogSchema.safeParse({ completedAt: '2020-01-01', notes: longNotes })
+
+    expect(result.success).toBe(false)
+    expect(result.error?.issues[0].message).toBe(
+      `Le champ 'notes' ne peut pas dépasser 500 caractères.`
+    )
+  })
+})

--- a/apps/web/src/features/check-logs/schemas/checkLog.schema.ts
+++ b/apps/web/src/features/check-logs/schemas/checkLog.schema.ts
@@ -6,6 +6,9 @@ export const createCheckLogSchema = z.object({
     .regex(/^\d{4}-\d{2}-\d{2}$/, {
       error: `Le champ 'completedAt' doit être une date au format YYYY-MM-DD.`
     })
+    .refine(dateString => !isNaN(Date.parse(dateString)), {
+      error: `Le champ 'completedAt' doit être une date valide.`
+    })
     .refine(
       dateString => {
         const today = new Date()

--- a/apps/web/src/features/check-logs/schemas/checkLog.schema.ts
+++ b/apps/web/src/features/check-logs/schemas/checkLog.schema.ts
@@ -1,0 +1,23 @@
+import { z } from 'zod'
+
+export const createCheckLogSchema = z.object({
+  completedAt: z
+    .string({ error: `Le champ 'completedAt' est requis.` })
+    .regex(/^\d{4}-\d{2}-\d{2}$/, {
+      error: `Le champ 'completedAt' doit être une date au format YYYY-MM-DD.`
+    })
+    .refine(
+      dateString => {
+        const today = new Date()
+        const todayStr = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}`
+        return dateString <= todayStr
+      },
+      { error: `Le champ 'completedAt' ne peut pas être une date future.` }
+    ),
+  notes: z
+    .string()
+    .max(500, { error: `Le champ 'notes' ne peut pas dépasser 500 caractères.` })
+    .optional()
+})
+
+export type CreateCheckLogSchema = z.infer<typeof createCheckLogSchema>

--- a/apps/web/src/features/check-logs/schemas/index.ts
+++ b/apps/web/src/features/check-logs/schemas/index.ts
@@ -1,0 +1,1 @@
+export { createCheckLogSchema, type CreateCheckLogSchema } from './checkLog.schema'

--- a/apps/web/src/features/check-logs/types/checkLog.types.ts
+++ b/apps/web/src/features/check-logs/types/checkLog.types.ts
@@ -1,0 +1,26 @@
+export interface CheckLog {
+  id: string
+  checkTypeId: string
+  checkTypeName: string
+  completedAt: string
+  notes: string | null
+  nextDueAt: string
+  createdAt: string
+}
+
+export type CheckStatus = 'on-time' | 'due-soon' | 'overdue' | 'never'
+
+export interface CheckStatusSummary {
+  checkTypeId: string
+  checkTypeName: string
+  intervalDays: number
+  lastCompletedAt: string | null
+  nextDueAt: string | null
+  status: CheckStatus
+}
+
+export interface CreateCheckLogInput {
+  checkTypeId: string
+  completedAt: string
+  notes?: string
+}

--- a/apps/web/src/features/check-logs/types/index.ts
+++ b/apps/web/src/features/check-logs/types/index.ts
@@ -1,0 +1,6 @@
+export type {
+  CheckLog,
+  CheckStatus,
+  CheckStatusSummary,
+  CreateCheckLogInput
+} from './checkLog.types'

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -8,18 +8,18 @@
 
 #### Phase 1: Database & Types Foundation
 
-- [ ] Prisma schema: CheckLog model + migration
-- [ ] Frontend types: CheckLog, CheckStatus, CheckStatusSummary
-- [ ] Backend validation constants
-- [ ] Frontend Zod schema + tests
+- [x] Prisma schema: CheckLog model + migration
+- [x] Frontend types: CheckLog, CheckStatus, CheckStatusSummary
+- [x] Backend validation constants
+- [x] Frontend Zod schema + tests
 
 #### Phase 2: Backend Domain Layer
 
-- [ ] CheckLogId value object + tests
-- [ ] CompletedAt value object + tests
-- [ ] CheckLog entity + tests
-- [ ] Domain exceptions (CheckLogNotFound, InvalidCheckLog)
-- [ ] Repository interface (ICheckLogRepository)
+- [x] CheckLogId value object + tests
+- [x] CompletedAt value object + tests
+- [x] CheckLog entity + tests
+- [x] Domain exceptions (CheckLogNotFound, InvalidCheckLog)
+- [x] Repository interface (ICheckLogRepository)
 
 ---
 


### PR DESCRIPTION
## Summary

- Prisma CheckLog model with String dates (YYYY-MM-DD) and cascade delete from CheckType
- Frontend types (CheckLog, CheckStatus, CheckStatusSummary) and Zod validation schema with date-only + not-in-future validation
- Backend domain layer: CheckLogId and CompletedAt value objects, immutable CheckLog entity, domain exceptions, repository interface

## Block 1 of 4 — Feature 04: Check Logging

This PR covers Phases 1-2 (Database & Types Foundation + Backend Domain Layer). Next blocks will add application layer, infrastructure, frontend components, and integration.

## Test plan

- [x] All existing 530+ tests still pass
- [x] 8 new Zod schema tests (date format, future rejection, notes max length)
- [x] 8 new CheckLogId VO tests (UUID validation, generate, equals)
- [x] 11 new CompletedAt VO tests (format, Date.parse, future rejection, toDate UTC)
- [x] 4 new CheckLog entity tests (creation, null notes, max length, immutability)
- [x] Typecheck, lint, format all pass