### PR TITLE
feat(check-logging): add application layer, infrastructure, and API (Block 2)

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common'
 import { ConfigModule } from '@nestjs/config'
 
 import { AuthModule } from '~/auth/Auth.module'
+import { CheckLogsModule } from '~/check-logs/CheckLogs.module'
 import { CheckTypesModule } from '~/check-types/CheckTypes.module'
 import { PrismaModule } from '~/shared/infrastructure/database'
 import { SharedModule } from '~/shared/Shared.module'
@@ -18,6 +19,7 @@ import { VehiclesModule } from '~/vehicles/Vehicles.module'
     UsersModule,
     VehiclesModule,
     CheckTypesModule,
+    CheckLogsModule,
     AuthModule
   ]
 })

--- a/apps/api/src/check-logs/CheckLogs.module.ts
+++ b/apps/api/src/check-logs/CheckLogs.module.ts
@@ -1,0 +1,64 @@
+import { Module } from '@nestjs/common'
+
+import { AuthModule } from '~/auth/Auth.module'
+import { CheckTypeService } from '~/check-types/application/services'
+import { CheckTypesModule } from '~/check-types/CheckTypes.module'
+import { PrismaProvider } from '~/shared/infrastructure/database'
+import { VehiclesModule } from '~/vehicles/Vehicles.module'
+
+import { CheckLogService } from './application/services'
+import {
+  CreateCheckLogUseCase,
+  DeleteCheckLogUseCase,
+  GetCheckLogUseCase,
+  GetCheckStatusSummaryUseCase,
+  ListCheckLogsByVehicleUseCase
+} from './application/use-cases'
+import type { ICheckLogRepository } from './domain/repositories'
+import { CheckLogController, CheckStatusController } from './infrastructure/controllers'
+import { PrismaCheckLogRepository } from './infrastructure/repositories'
+
+@Module({
+  imports: [AuthModule, VehiclesModule, CheckTypesModule],
+  controllers: [CheckLogController, CheckStatusController],
+  providers: [
+    {
+      provide: 'ICheckLogRepository',
+      useFactory: (prisma: PrismaProvider) => new PrismaCheckLogRepository(prisma),
+      inject: [PrismaProvider]
+    },
+    {
+      provide: CreateCheckLogUseCase,
+      useFactory: (checkLogRepository: ICheckLogRepository, checkTypeService: CheckTypeService) =>
+        new CreateCheckLogUseCase(checkLogRepository, checkTypeService),
+      inject: ['ICheckLogRepository', CheckTypeService]
+    },
+    {
+      provide: ListCheckLogsByVehicleUseCase,
+      useFactory: (checkLogRepository: ICheckLogRepository, checkTypeService: CheckTypeService) =>
+        new ListCheckLogsByVehicleUseCase(checkLogRepository, checkTypeService),
+      inject: ['ICheckLogRepository', CheckTypeService]
+    },
+    {
+      provide: GetCheckLogUseCase,
+      useFactory: (checkLogRepository: ICheckLogRepository, checkTypeService: CheckTypeService) =>
+        new GetCheckLogUseCase(checkLogRepository, checkTypeService),
+      inject: ['ICheckLogRepository', CheckTypeService]
+    },
+    {
+      provide: DeleteCheckLogUseCase,
+      useFactory: (checkLogRepository: ICheckLogRepository, checkTypeService: CheckTypeService) =>
+        new DeleteCheckLogUseCase(checkLogRepository, checkTypeService),
+      inject: ['ICheckLogRepository', CheckTypeService]
+    },
+    {
+      provide: GetCheckStatusSummaryUseCase,
+      useFactory: (checkLogRepository: ICheckLogRepository, checkTypeService: CheckTypeService) =>
+        new GetCheckStatusSummaryUseCase(checkLogRepository, checkTypeService),
+      inject: ['ICheckLogRepository', CheckTypeService]
+    },
+    CheckLogService
+  ],
+  exports: [CheckLogService]
+})
+export class CheckLogsModule {}

--- a/apps/api/src/check-logs/application/dtos/CheckStatusSummary.dto.spec.ts
+++ b/apps/api/src/check-logs/application/dtos/CheckStatusSummary.dto.spec.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'bun:test'
+
+import { CheckStatusSummaryDto } from './CheckStatusSummary.dto'
+
+describe('CheckStatusSummaryDto', () => {
+  const getDto = (overrides: Partial<CheckStatusSummaryDto> = {}): CheckStatusSummaryDto =>
+    Object.assign(new CheckStatusSummaryDto(), {
+      checkTypeId: '660e8400-e29b-41d4-a716-446655440000',
+      checkTypeName: 'Vidange',
+      intervalDays: 7,
+      lastCompletedAt: '2026-03-15',
+      nextDueAt: '2026-03-22',
+      status: 'on-time' as const,
+      ...overrides
+    })
+
+  it('should create instance with all properties', () => {
+    const dto = getDto()
+
+    expect(dto).toBeInstanceOf(CheckStatusSummaryDto)
+    expect(dto.checkTypeId).toBe('660e8400-e29b-41d4-a716-446655440000')
+    expect(dto.checkTypeName).toBe('Vidange')
+    expect(dto.intervalDays).toBe(7)
+    expect(dto.lastCompletedAt).toBe('2026-03-15')
+    expect(dto.nextDueAt).toBe('2026-03-22')
+    expect(dto.status).toBe('on-time')
+  })
+
+  it('should handle never status with null dates', () => {
+    const dto = getDto({ lastCompletedAt: null, nextDueAt: null, status: 'never' })
+
+    expect(dto).toBeInstanceOf(CheckStatusSummaryDto)
+    expect(dto.lastCompletedAt).toBeNull()
+    expect(dto.nextDueAt).toBeNull()
+    expect(dto.status).toBe('never')
+  })
+
+  it('should be serializable to JSON', () => {
+    const dto = getDto()
+
+    const json = JSON.stringify(dto)
+    const parsed = JSON.parse(json)
+
+    expect(parsed.checkTypeId).toBe(dto.checkTypeId)
+    expect(parsed.checkTypeName).toBe(dto.checkTypeName)
+    expect(parsed.status).toBe(dto.status)
+    expect(parsed.lastCompletedAt).toBe(dto.lastCompletedAt)
+    expect(parsed.nextDueAt).toBe(dto.nextDueAt)
+  })
+})

--- a/apps/api/src/check-logs/application/dtos/CheckStatusSummary.dto.ts
+++ b/apps/api/src/check-logs/application/dtos/CheckStatusSummary.dto.ts
@@ -1,0 +1,10 @@
+export type CheckStatus = 'on-time' | 'due-soon' | 'overdue' | 'never'
+
+export class CheckStatusSummaryDto {
+  checkTypeId!: string
+  checkTypeName!: string
+  intervalDays!: number
+  lastCompletedAt!: string | null
+  nextDueAt!: string | null
+  status!: CheckStatus
+}

--- a/apps/api/src/check-logs/application/dtos/CreateCheckLog.dto.spec.ts
+++ b/apps/api/src/check-logs/application/dtos/CreateCheckLog.dto.spec.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'bun:test'
+
+import { CreateCheckLogDto } from './CreateCheckLog.dto'
+
+describe('CreateCheckLogDto', () => {
+  const createDto = (overrides: Partial<CreateCheckLogDto> = {}): CreateCheckLogDto =>
+    Object.assign(new CreateCheckLogDto(), {
+      checkTypeId: '550e8400-e29b-41d4-a716-446655440000',
+      completedAt: '2026-03-15',
+      notes: 'All good',
+      ...overrides
+    })
+
+  it('should create instance with all properties', () => {
+    const dto = createDto()
+
+    expect(dto).toBeInstanceOf(CreateCheckLogDto)
+    expect(dto.checkTypeId).toBe('550e8400-e29b-41d4-a716-446655440000')
+    expect(dto.completedAt).toBe('2026-03-15')
+    expect(dto.notes).toBe('All good')
+  })
+
+  it('should create instance without optional notes', () => {
+    const dto = createDto({ notes: undefined })
+
+    expect(dto).toBeInstanceOf(CreateCheckLogDto)
+    expect(dto.checkTypeId).toBe('550e8400-e29b-41d4-a716-446655440000')
+    expect(dto.completedAt).toBe('2026-03-15')
+    expect(dto.notes).toBeUndefined()
+  })
+
+  it('should be serializable to JSON', () => {
+    const dto = createDto()
+
+    const json = JSON.stringify(dto)
+    const parsed = JSON.parse(json)
+
+    expect(parsed.checkTypeId).toBe(dto.checkTypeId)
+    expect(parsed.completedAt).toBe(dto.completedAt)
+    expect(parsed.notes).toBe(dto.notes)
+  })
+})

--- a/apps/api/src/check-logs/application/dtos/CreateCheckLog.dto.ts
+++ b/apps/api/src/check-logs/application/dtos/CreateCheckLog.dto.ts
@@ -1,0 +1,19 @@
+import { IsNotEmpty, IsOptional, IsString, IsUUID, Matches, MaxLength } from 'class-validator'
+
+import { CHECK_LOG_VALIDATION as checkLogValidation } from '~/check-logs/domain/validation'
+
+export class CreateCheckLogDto {
+  @IsNotEmpty({ message: 'CheckTypeId cannot be empty' })
+  @IsUUID('4', { message: 'CheckTypeId must be a valid UUID' })
+  checkTypeId!: string
+
+  @IsString()
+  @IsNotEmpty({ message: 'CompletedAt cannot be empty' })
+  @Matches(/^\d{4}-\d{2}-\d{2}$/, { message: checkLogValidation.COMPLETED_AT.MESSAGE })
+  completedAt!: string
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(checkLogValidation.NOTES.MAX_LENGTH, { message: checkLogValidation.NOTES.MESSAGE })
+  notes?: string
+}

--- a/apps/api/src/check-logs/application/dtos/GetCheckLog.dto.spec.ts
+++ b/apps/api/src/check-logs/application/dtos/GetCheckLog.dto.spec.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'bun:test'
+
+import { GetCheckLogDto } from './GetCheckLog.dto'
+
+describe('GetCheckLogDto', () => {
+  const getDto = (overrides: Partial<GetCheckLogDto> = {}): GetCheckLogDto =>
+    Object.assign(new GetCheckLogDto(), {
+      id: '550e8400-e29b-41d4-a716-446655440000',
+      checkTypeId: '660e8400-e29b-41d4-a716-446655440000',
+      checkTypeName: 'Vidange',
+      completedAt: '2026-03-15',
+      notes: 'All good',
+      nextDueAt: '2026-03-22',
+      createdAt: new Date('2026-03-15T10:00:00Z'),
+      ...overrides
+    })
+
+  it('should create instance with all properties', () => {
+    const dto = getDto()
+
+    expect(dto).toBeInstanceOf(GetCheckLogDto)
+    expect(dto.id).toBe('550e8400-e29b-41d4-a716-446655440000')
+    expect(dto.checkTypeId).toBe('660e8400-e29b-41d4-a716-446655440000')
+    expect(dto.checkTypeName).toBe('Vidange')
+    expect(dto.completedAt).toBe('2026-03-15')
+    expect(dto.notes).toBe('All good')
+    expect(dto.nextDueAt).toBe('2026-03-22')
+    expect(dto.createdAt).toEqual(new Date('2026-03-15T10:00:00Z'))
+  })
+
+  it('should handle null notes', () => {
+    const dto = getDto({ notes: null })
+
+    expect(dto).toBeInstanceOf(GetCheckLogDto)
+    expect(dto.notes).toBeNull()
+  })
+
+  it('should be serializable to JSON', () => {
+    const dto = getDto()
+
+    const json = JSON.stringify(dto)
+    const parsed = JSON.parse(json)
+
+    expect(parsed.id).toBe(dto.id)
+    expect(parsed.checkTypeName).toBe(dto.checkTypeName)
+    expect(parsed.completedAt).toBe(dto.completedAt)
+    expect(parsed.nextDueAt).toBe(dto.nextDueAt)
+  })
+})

--- a/apps/api/src/check-logs/application/dtos/GetCheckLog.dto.ts
+++ b/apps/api/src/check-logs/application/dtos/GetCheckLog.dto.ts
@@ -1,0 +1,9 @@
+export class GetCheckLogDto {
+  id!: string
+  checkTypeId!: string
+  checkTypeName!: string
+  completedAt!: string
+  notes!: string | null
+  nextDueAt!: string
+  createdAt!: Date
+}

--- a/apps/api/src/check-logs/application/dtos/index.ts
+++ b/apps/api/src/check-logs/application/dtos/index.ts
@@ -1,0 +1,3 @@
+export { CheckStatusSummaryDto, type CheckStatus } from './CheckStatusSummary.dto'
+export { CreateCheckLogDto } from './CreateCheckLog.dto'
+export { GetCheckLogDto } from './GetCheckLog.dto'

--- a/apps/api/src/check-logs/application/mappers/CheckLog.mapper.spec.ts
+++ b/apps/api/src/check-logs/application/mappers/CheckLog.mapper.spec.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from 'bun:test'
+
+import { CheckLogEntity } from '~/check-logs/domain/entities'
+import { CheckLogIdValueObject, CompletedAtValueObject } from '~/check-logs/domain/value-objects'
+import { GetCheckTypeDto } from '~/check-types/application/dtos'
+
+import { CheckStatusSummaryDto, GetCheckLogDto } from '../dtos'
+
+import { CheckLogMapper } from './CheckLog.mapper'
+
+describe('CheckLogMapper', () => {
+  const makeCheckType = (overrides: Partial<GetCheckTypeDto> = {}): GetCheckTypeDto =>
+    Object.assign(new GetCheckTypeDto(), {
+      id: '660e8400-e29b-41d4-a716-446655440000',
+      vehicleId: '770e8400-e29b-41d4-a716-446655440000',
+      name: 'Vidange',
+      description: null,
+      intervalDays: 7,
+      createdAt: new Date('2026-01-01T00:00:00Z'),
+      updatedAt: new Date('2026-01-01T00:00:00Z'),
+      ...overrides
+    })
+
+  const makeEntity = (
+    completedAt: string,
+    nextDueAt: string,
+    notes: string | null = 'All good'
+  ): CheckLogEntity =>
+    new CheckLogEntity(
+      new CheckLogIdValueObject('550e8400-e29b-41d4-a716-446655440000'),
+      '660e8400-e29b-41d4-a716-446655440000',
+      new CompletedAtValueObject(completedAt),
+      notes,
+      nextDueAt,
+      new Date('2026-03-15T10:00:00Z'),
+      new Date('2026-03-15T10:00:00Z')
+    )
+
+  const toDateStr = (date: Date): string => {
+    const y = date.getUTCFullYear()
+    const m = String(date.getUTCMonth() + 1).padStart(2, '0')
+    const d = String(date.getUTCDate()).padStart(2, '0')
+
+    return `${y}-${m}-${d}`
+  }
+
+  describe('toGetCheckLogDto', () => {
+    it('should map entity to DTO with all fields', () => {
+      const entity = makeEntity('2026-03-14', '2026-03-21')
+      const dto = CheckLogMapper.toGetCheckLogDto(entity, 'Vidange')
+
+      expect(dto).toBeInstanceOf(GetCheckLogDto)
+      expect(dto.id).toBe('550e8400-e29b-41d4-a716-446655440000')
+      expect(dto.checkTypeId).toBe('660e8400-e29b-41d4-a716-446655440000')
+      expect(dto.checkTypeName).toBe('Vidange')
+      expect(dto.completedAt).toBe('2026-03-14')
+      expect(dto.notes).toBe('All good')
+      expect(dto.nextDueAt).toBe('2026-03-21')
+      expect(dto.createdAt).toEqual(new Date('2026-03-15T10:00:00Z'))
+    })
+
+    it('should map entity with null notes', () => {
+      const entity = makeEntity('2026-03-14', '2026-03-21', null)
+      const dto = CheckLogMapper.toGetCheckLogDto(entity, 'Vidange')
+
+      expect(dto).toBeInstanceOf(GetCheckLogDto)
+      expect(dto.notes).toBeNull()
+    })
+
+    it('should return a GetCheckLogDto instance', () => {
+      const entity = makeEntity('2026-03-14', '2026-03-21')
+      const dto = CheckLogMapper.toGetCheckLogDto(entity, 'Vidange')
+
+      expect(dto).toBeInstanceOf(GetCheckLogDto)
+    })
+  })
+
+  describe('toCheckStatusSummaryDto', () => {
+    it('should return "never" when no log exists', () => {
+      const checkType = makeCheckType()
+      const summary = CheckLogMapper.toCheckStatusSummaryDto(checkType, null)
+
+      expect(summary).toBeInstanceOf(CheckStatusSummaryDto)
+      expect(summary.status).toBe('never')
+      expect(summary.lastCompletedAt).toBeNull()
+      expect(summary.nextDueAt).toBeNull()
+      expect(summary.checkTypeId).toBe(checkType.id)
+      expect(summary.checkTypeName).toBe(checkType.name)
+      expect(summary.intervalDays).toBe(checkType.intervalDays)
+    })
+
+    it('should return "overdue" when nextDueAt is in the past', () => {
+      const checkType = makeCheckType()
+      const entity = makeEntity('2020-01-01', '2020-01-08')
+      const summary = CheckLogMapper.toCheckStatusSummaryDto(checkType, entity)
+
+      expect(summary).toBeInstanceOf(CheckStatusSummaryDto)
+      expect(summary.status).toBe('overdue')
+    })
+
+    it('should return "due-soon" when nextDueAt is today (boundary: 0 days)', () => {
+      const checkType = makeCheckType()
+      const entity = makeEntity('2020-01-01', toDateStr(new Date()))
+      const summary = CheckLogMapper.toCheckStatusSummaryDto(checkType, entity)
+
+      expect(summary.status).toBe('due-soon')
+    })
+
+    it('should return "due-soon" when nextDueAt is tomorrow', () => {
+      const checkType = makeCheckType()
+      const tomorrow = new Date(Date.now() + 1 * 24 * 60 * 60 * 1000)
+      const entity = makeEntity('2020-01-01', toDateStr(tomorrow))
+      const summary = CheckLogMapper.toCheckStatusSummaryDto(checkType, entity)
+
+      expect(summary.status).toBe('due-soon')
+    })
+
+    it('should return "due-soon" when nextDueAt is exactly 2 days away (boundary)', () => {
+      const checkType = makeCheckType()
+      const inTwoDays = new Date(Date.now() + 2 * 24 * 60 * 60 * 1000)
+      const entity = makeEntity('2020-01-01', toDateStr(inTwoDays))
+      const summary = CheckLogMapper.toCheckStatusSummaryDto(checkType, entity)
+
+      expect(summary.status).toBe('due-soon')
+    })
+
+    it('should return "on-time" when nextDueAt is exactly 3 days away (boundary)', () => {
+      const checkType = makeCheckType()
+      const inThreeDays = new Date(Date.now() + 3 * 24 * 60 * 60 * 1000)
+      const entity = makeEntity('2020-01-01', toDateStr(inThreeDays))
+      const summary = CheckLogMapper.toCheckStatusSummaryDto(checkType, entity)
+
+      expect(summary.status).toBe('on-time')
+    })
+
+    it('should return "on-time" when nextDueAt is far in the future', () => {
+      const checkType = makeCheckType()
+      const entity = makeEntity('2026-03-14', '2099-01-01')
+      const summary = CheckLogMapper.toCheckStatusSummaryDto(checkType, entity)
+
+      expect(summary).toBeInstanceOf(CheckStatusSummaryDto)
+      expect(summary.status).toBe('on-time')
+    })
+
+    it('should include checkType fields in the summary', () => {
+      const checkType = makeCheckType({
+        id: '123e4567-e89b-12d3-a456-426614174000',
+        name: 'Test Check',
+        intervalDays: 14
+      })
+      const entity = makeEntity('2026-03-14', '2099-01-01')
+      const summary = CheckLogMapper.toCheckStatusSummaryDto(checkType, entity)
+
+      expect(summary).toBeInstanceOf(CheckStatusSummaryDto)
+      expect(summary.checkTypeId).toBe('123e4567-e89b-12d3-a456-426614174000')
+      expect(summary.checkTypeName).toBe('Test Check')
+      expect(summary.intervalDays).toBe(14)
+    })
+
+    it('should return a CheckStatusSummaryDto instance', () => {
+      const checkType = makeCheckType()
+      const entity = makeEntity('2026-03-14', '2099-01-01')
+      const summary = CheckLogMapper.toCheckStatusSummaryDto(checkType, entity)
+
+      expect(summary).toBeInstanceOf(CheckStatusSummaryDto)
+    })
+  })
+})

--- a/apps/api/src/check-logs/application/mappers/CheckLog.mapper.ts
+++ b/apps/api/src/check-logs/application/mappers/CheckLog.mapper.ts
@@ -1,0 +1,64 @@
+import type { CheckLogEntity } from '~/check-logs/domain/entities'
+import type { GetCheckTypeDto } from '~/check-types/application/dtos'
+
+import type { CheckStatus } from '../dtos'
+import { CheckStatusSummaryDto, GetCheckLogDto } from '../dtos'
+
+const DUE_SOON_THRESHOLD_DAYS = 2
+
+const computeStatus = (nextDueAt: string): CheckStatus => {
+  const nextDueAtDate = new Date(nextDueAt + 'T00:00:00Z')
+  const today = new Date()
+  today.setUTCHours(0, 0, 0, 0)
+
+  const msPerDay = 24 * 60 * 60 * 1000
+  const daysRemaining = (nextDueAtDate.getTime() - today.getTime()) / msPerDay
+
+  if (daysRemaining < 0) return 'overdue'
+  if (daysRemaining <= DUE_SOON_THRESHOLD_DAYS) return 'due-soon'
+
+  return 'on-time'
+}
+
+export class CheckLogMapper {
+  static toGetCheckLogDto(entity: CheckLogEntity, checkTypeName: string): GetCheckLogDto {
+    const dto: GetCheckLogDto = {
+      id: entity.id.value,
+      checkTypeId: entity.checkTypeId,
+      checkTypeName,
+      completedAt: entity.completedAt.value,
+      notes: entity.notes,
+      nextDueAt: entity.nextDueAt,
+      createdAt: entity.createdAt
+    }
+
+    return Object.assign(new GetCheckLogDto(), dto)
+  }
+
+  static toCheckStatusSummaryDto(
+    checkType: GetCheckTypeDto,
+    latestLog: CheckLogEntity | null
+  ): CheckStatusSummaryDto {
+    const base = {
+      checkTypeId: checkType.id,
+      checkTypeName: checkType.name,
+      intervalDays: checkType.intervalDays
+    }
+
+    if (!latestLog) {
+      return Object.assign(new CheckStatusSummaryDto(), {
+        ...base,
+        status: 'never' as CheckStatus,
+        lastCompletedAt: null,
+        nextDueAt: null
+      })
+    }
+
+    return Object.assign(new CheckStatusSummaryDto(), {
+      ...base,
+      status: computeStatus(latestLog.nextDueAt),
+      lastCompletedAt: latestLog.completedAt.value,
+      nextDueAt: latestLog.nextDueAt
+    })
+  }
+}

--- a/apps/api/src/check-logs/application/mappers/index.ts
+++ b/apps/api/src/check-logs/application/mappers/index.ts
@@ -1,0 +1,1 @@
+export { CheckLogMapper } from './CheckLog.mapper'

--- a/apps/api/src/check-logs/application/services/CheckLog.service.spec.ts
+++ b/apps/api/src/check-logs/application/services/CheckLog.service.spec.ts
@@ -1,0 +1,120 @@
+import { Test } from '@nestjs/testing'
+import type { Mock } from 'bun:test'
+import { beforeEach, describe, expect, it, mock } from 'bun:test'
+
+import {
+  CreateCheckLogUseCase,
+  DeleteCheckLogUseCase,
+  GetCheckLogUseCase,
+  GetCheckStatusSummaryUseCase,
+  ListCheckLogsByVehicleUseCase
+} from '~/check-logs/application/use-cases'
+
+import { CheckLogService } from './CheckLog.service'
+
+describe('CheckLogService', () => {
+  let service: CheckLogService
+  let mockCreateCheckLogUseCase: {
+    execute: Mock<typeof CreateCheckLogUseCase.prototype.execute>
+  }
+  let mockListCheckLogsByVehicleUseCase: {
+    execute: Mock<typeof ListCheckLogsByVehicleUseCase.prototype.execute>
+  }
+  let mockGetCheckLogUseCase: {
+    execute: Mock<typeof GetCheckLogUseCase.prototype.execute>
+  }
+  let mockDeleteCheckLogUseCase: {
+    execute: Mock<typeof DeleteCheckLogUseCase.prototype.execute>
+  }
+  let mockGetCheckStatusSummaryUseCase: {
+    execute: Mock<typeof GetCheckStatusSummaryUseCase.prototype.execute>
+  }
+
+  beforeEach(async () => {
+    mockCreateCheckLogUseCase = {
+      execute: mock(() => {}) as unknown as Mock<typeof CreateCheckLogUseCase.prototype.execute>
+    }
+    mockListCheckLogsByVehicleUseCase = {
+      execute: mock(() => {}) as unknown as Mock<
+        typeof ListCheckLogsByVehicleUseCase.prototype.execute
+      >
+    }
+    mockGetCheckLogUseCase = {
+      execute: mock(() => {}) as unknown as Mock<typeof GetCheckLogUseCase.prototype.execute>
+    }
+    mockDeleteCheckLogUseCase = {
+      execute: mock(() => {}) as unknown as Mock<typeof DeleteCheckLogUseCase.prototype.execute>
+    }
+    mockGetCheckStatusSummaryUseCase = {
+      execute: mock(() => {}) as unknown as Mock<
+        typeof GetCheckStatusSummaryUseCase.prototype.execute
+      >
+    }
+
+    const module = await Test.createTestingModule({
+      providers: [
+        CheckLogService,
+        { provide: CreateCheckLogUseCase, useValue: mockCreateCheckLogUseCase },
+        { provide: ListCheckLogsByVehicleUseCase, useValue: mockListCheckLogsByVehicleUseCase },
+        { provide: GetCheckLogUseCase, useValue: mockGetCheckLogUseCase },
+        { provide: DeleteCheckLogUseCase, useValue: mockDeleteCheckLogUseCase },
+        { provide: GetCheckStatusSummaryUseCase, useValue: mockGetCheckStatusSummaryUseCase }
+      ]
+    }).compile()
+
+    service = module.get<CheckLogService>(CheckLogService)
+  })
+
+  describe('createCheckLog', () => {
+    it('should delegate to createCheckLogUseCase with correct parameters', async () => {
+      const dto = { checkTypeId: 'ct-123', completedAt: '2026-03-15', notes: 'OK' }
+      const vehicleId = 'vehicle-123'
+
+      await service.createCheckLog(dto, vehicleId)
+
+      expect(mockCreateCheckLogUseCase.execute).toHaveBeenCalledWith(dto, vehicleId)
+    })
+  })
+
+  describe('listCheckLogsByVehicle', () => {
+    it('should delegate to listCheckLogsByVehicleUseCase with correct parameters', async () => {
+      const vehicleId = 'vehicle-123'
+
+      await service.listCheckLogsByVehicle(vehicleId)
+
+      expect(mockListCheckLogsByVehicleUseCase.execute).toHaveBeenCalledWith(vehicleId)
+    })
+  })
+
+  describe('getCheckLog', () => {
+    it('should delegate to getCheckLogUseCase with correct parameters', async () => {
+      const id = 'log-123'
+      const vehicleId = 'vehicle-123'
+
+      await service.getCheckLog(id, vehicleId)
+
+      expect(mockGetCheckLogUseCase.execute).toHaveBeenCalledWith(id, vehicleId)
+    })
+  })
+
+  describe('deleteCheckLog', () => {
+    it('should delegate to deleteCheckLogUseCase with correct parameters', async () => {
+      const id = 'log-123'
+      const vehicleId = 'vehicle-123'
+
+      await service.deleteCheckLog(id, vehicleId)
+
+      expect(mockDeleteCheckLogUseCase.execute).toHaveBeenCalledWith(id, vehicleId)
+    })
+  })
+
+  describe('getCheckStatusSummary', () => {
+    it('should delegate to getCheckStatusSummaryUseCase with correct parameters', async () => {
+      const vehicleId = 'vehicle-123'
+
+      await service.getCheckStatusSummary(vehicleId)
+
+      expect(mockGetCheckStatusSummaryUseCase.execute).toHaveBeenCalledWith(vehicleId)
+    })
+  })
+})

--- a/apps/api/src/check-logs/application/services/CheckLog.service.ts
+++ b/apps/api/src/check-logs/application/services/CheckLog.service.ts
@@ -1,0 +1,45 @@
+import { Injectable } from '@nestjs/common'
+
+import type {
+  CheckStatusSummaryDto,
+  CreateCheckLogDto,
+  GetCheckLogDto
+} from '~/check-logs/application/dtos'
+import {
+  CreateCheckLogUseCase,
+  DeleteCheckLogUseCase,
+  GetCheckLogUseCase,
+  GetCheckStatusSummaryUseCase,
+  ListCheckLogsByVehicleUseCase
+} from '~/check-logs/application/use-cases'
+
+@Injectable()
+export class CheckLogService {
+  constructor(
+    private readonly createCheckLogUseCase: CreateCheckLogUseCase,
+    private readonly listCheckLogsByVehicleUseCase: ListCheckLogsByVehicleUseCase,
+    private readonly getCheckLogUseCase: GetCheckLogUseCase,
+    private readonly deleteCheckLogUseCase: DeleteCheckLogUseCase,
+    private readonly getCheckStatusSummaryUseCase: GetCheckStatusSummaryUseCase
+  ) {}
+
+  async createCheckLog(dto: CreateCheckLogDto, vehicleId: string): Promise<GetCheckLogDto> {
+    return this.createCheckLogUseCase.execute(dto, vehicleId)
+  }
+
+  async listCheckLogsByVehicle(vehicleId: string): Promise<GetCheckLogDto[]> {
+    return this.listCheckLogsByVehicleUseCase.execute(vehicleId)
+  }
+
+  async getCheckLog(id: string, vehicleId: string): Promise<GetCheckLogDto> {
+    return this.getCheckLogUseCase.execute(id, vehicleId)
+  }
+
+  async deleteCheckLog(id: string, vehicleId: string): Promise<void> {
+    return this.deleteCheckLogUseCase.execute(id, vehicleId)
+  }
+
+  async getCheckStatusSummary(vehicleId: string): Promise<CheckStatusSummaryDto[]> {
+    return this.getCheckStatusSummaryUseCase.execute(vehicleId)
+  }
+}

--- a/apps/api/src/check-logs/application/services/index.ts
+++ b/apps/api/src/check-logs/application/services/index.ts
@@ -1,0 +1,1 @@
+export { CheckLogService } from './CheckLog.service'

--- a/apps/api/src/check-logs/application/use-cases/CreateCheckLog.uc.spec.ts
+++ b/apps/api/src/check-logs/application/use-cases/CreateCheckLog.uc.spec.ts
@@ -1,0 +1,120 @@
+import type { Mock } from 'bun:test'
+import { beforeEach, describe, expect, it, mock } from 'bun:test'
+
+import type { ICheckLogRepository } from '~/check-logs/domain/repositories'
+import type { GetCheckTypeDto } from '~/check-types/application/dtos'
+import type { CheckTypeService } from '~/check-types/application/services'
+
+import type { CreateCheckLogDto } from '../dtos'
+
+import { CreateCheckLogUseCase } from './CreateCheckLog.uc'
+
+describe('CreateCheckLogUseCase', () => {
+  let useCase: CreateCheckLogUseCase
+  let mockRepository: {
+    create: Mock<ICheckLogRepository['create']>
+    findById: Mock<ICheckLogRepository['findById']>
+    findByCheckTypeId: Mock<ICheckLogRepository['findByCheckTypeId']>
+    findByVehicleId: Mock<ICheckLogRepository['findByVehicleId']>
+    findMostRecentByCheckTypeIds: Mock<ICheckLogRepository['findMostRecentByCheckTypeIds']>
+    delete: Mock<ICheckLogRepository['delete']>
+  }
+  let mockCheckTypeService: {
+    getCheckType: Mock<CheckTypeService['getCheckType']>
+  }
+
+  const vehicleId = 'vehicle-123'
+  const checkTypeDto: GetCheckTypeDto = {
+    id: '660e8400-e29b-41d4-a716-446655440000',
+    vehicleId,
+    name: 'Vidange',
+    description: null,
+    intervalDays: 7,
+    createdAt: new Date('2026-01-01T00:00:00Z'),
+    updatedAt: new Date('2026-01-01T00:00:00Z')
+  }
+
+  beforeEach(() => {
+    mockRepository = {
+      create: mock(() => {}) as unknown as Mock<ICheckLogRepository['create']>,
+      findById: mock(() => {}) as unknown as Mock<ICheckLogRepository['findById']>,
+      findByCheckTypeId: mock(() => {}) as unknown as Mock<
+        ICheckLogRepository['findByCheckTypeId']
+      >,
+      findByVehicleId: mock(() => {}) as unknown as Mock<ICheckLogRepository['findByVehicleId']>,
+      findMostRecentByCheckTypeIds: mock(() => {}) as unknown as Mock<
+        ICheckLogRepository['findMostRecentByCheckTypeIds']
+      >,
+      delete: mock(() => {}) as unknown as Mock<ICheckLogRepository['delete']>
+    }
+    mockCheckTypeService = {
+      getCheckType: mock(() => {}) as unknown as Mock<CheckTypeService['getCheckType']>
+    }
+    useCase = new CreateCheckLogUseCase(
+      mockRepository as unknown as ICheckLogRepository,
+      mockCheckTypeService as unknown as CheckTypeService
+    )
+  })
+
+  describe('execute', () => {
+    it('should create a check log with calculated nextDueAt', async () => {
+      const dto: CreateCheckLogDto = {
+        checkTypeId: checkTypeDto.id,
+        completedAt: '2026-03-15',
+        notes: 'All good'
+      }
+
+      mockCheckTypeService.getCheckType.mockResolvedValueOnce(checkTypeDto)
+      mockRepository.create.mockImplementationOnce(async entity => entity)
+
+      const result = await useCase.execute(dto, vehicleId)
+
+      expect(result.nextDueAt).toBe('2026-03-22')
+      expect(mockCheckTypeService.getCheckType).toHaveBeenCalledWith(dto.checkTypeId, vehicleId)
+      expect(mockRepository.create).toHaveBeenCalledWith(
+        expect.objectContaining({ nextDueAt: '2026-03-22' })
+      )
+    })
+
+    it('should pass notes to the entity', async () => {
+      const dto: CreateCheckLogDto = {
+        checkTypeId: checkTypeDto.id,
+        completedAt: '2026-03-15',
+        notes: 'All good'
+      }
+
+      mockCheckTypeService.getCheckType.mockResolvedValueOnce(checkTypeDto)
+      mockRepository.create.mockImplementationOnce(async entity => entity)
+
+      const result = await useCase.execute(dto, vehicleId)
+
+      expect(result.notes).toBe('All good')
+    })
+
+    it('should default notes to null when not provided', async () => {
+      const dto: CreateCheckLogDto = {
+        checkTypeId: checkTypeDto.id,
+        completedAt: '2026-03-15'
+      }
+
+      mockCheckTypeService.getCheckType.mockResolvedValueOnce(checkTypeDto)
+      mockRepository.create.mockImplementationOnce(async entity => entity)
+
+      const result = await useCase.execute(dto, vehicleId)
+
+      expect(mockCheckTypeService.getCheckType).toHaveBeenCalledWith(dto.checkTypeId, vehicleId)
+      expect(result.notes).toBeNull()
+    })
+
+    it('should propagate error when check type not found', async () => {
+      const dto: CreateCheckLogDto = {
+        checkTypeId: 'non-existent-id',
+        completedAt: '2026-03-15'
+      }
+
+      mockCheckTypeService.getCheckType.mockRejectedValueOnce(new Error('Check type not found'))
+
+      await expect(useCase.execute(dto, vehicleId)).rejects.toThrow('Check type not found')
+    })
+  })
+})

--- a/apps/api/src/check-logs/application/use-cases/CreateCheckLog.uc.ts
+++ b/apps/api/src/check-logs/application/use-cases/CreateCheckLog.uc.ts
@@ -1,0 +1,39 @@
+import { Injectable } from '@nestjs/common'
+
+import type { CreateCheckLogDto, GetCheckLogDto } from '~/check-logs/application/dtos'
+import { CheckLogMapper } from '~/check-logs/application/mappers'
+import { CheckLogEntity } from '~/check-logs/domain/entities'
+import type { ICheckLogRepository } from '~/check-logs/domain/repositories'
+import { CheckLogIdValueObject, CompletedAtValueObject } from '~/check-logs/domain/value-objects'
+import type { CheckTypeService } from '~/check-types/application/services'
+
+@Injectable()
+export class CreateCheckLogUseCase {
+  constructor(
+    private readonly checkLogRepository: ICheckLogRepository,
+    private readonly checkTypeService: CheckTypeService
+  ) {}
+
+  async execute(dto: CreateCheckLogDto, vehicleId: string): Promise<GetCheckLogDto> {
+    const checkType = await this.checkTypeService.getCheckType(dto.checkTypeId, vehicleId)
+    const completedAt = new CompletedAtValueObject(dto.completedAt)
+
+    const completedAtDate = completedAt.toDate()
+    const nextDueAtDate = new Date(completedAtDate)
+    nextDueAtDate.setUTCDate(nextDueAtDate.getUTCDate() + checkType.intervalDays)
+    const nextDueAt = nextDueAtDate.toISOString().split('T')[0]
+
+    const entity = new CheckLogEntity(
+      CheckLogIdValueObject.generate(),
+      dto.checkTypeId,
+      completedAt,
+      dto.notes ?? null,
+      nextDueAt,
+      new Date(),
+      new Date()
+    )
+    const created = await this.checkLogRepository.create(entity)
+
+    return CheckLogMapper.toGetCheckLogDto(created, checkType.name)
+  }
+}

--- a/apps/api/src/check-logs/application/use-cases/DeleteCheckLog.uc.spec.ts
+++ b/apps/api/src/check-logs/application/use-cases/DeleteCheckLog.uc.spec.ts
@@ -1,0 +1,112 @@
+import type { Mock } from 'bun:test'
+import { beforeEach, describe, expect, it, mock } from 'bun:test'
+
+import { CheckLogEntity } from '~/check-logs/domain/entities'
+import type { ICheckLogRepository } from '~/check-logs/domain/repositories'
+import { CheckLogIdValueObject, CompletedAtValueObject } from '~/check-logs/domain/value-objects'
+import type { GetCheckTypeDto } from '~/check-types/application/dtos'
+import type { CheckTypeService } from '~/check-types/application/services'
+
+import { DeleteCheckLogUseCase } from './DeleteCheckLog.uc'
+
+const makeEntity = () =>
+  new CheckLogEntity(
+    CheckLogIdValueObject.generate(),
+    '660e8400-e29b-41d4-a716-446655440000',
+    new CompletedAtValueObject('2026-03-15'),
+    'All good',
+    '2026-03-22',
+    new Date(),
+    new Date()
+  )
+
+describe('DeleteCheckLogUseCase', () => {
+  let useCase: DeleteCheckLogUseCase
+  let mockRepository: {
+    create: Mock<ICheckLogRepository['create']>
+    findById: Mock<ICheckLogRepository['findById']>
+    findByCheckTypeId: Mock<ICheckLogRepository['findByCheckTypeId']>
+    findByVehicleId: Mock<ICheckLogRepository['findByVehicleId']>
+    findMostRecentByCheckTypeIds: Mock<ICheckLogRepository['findMostRecentByCheckTypeIds']>
+    delete: Mock<ICheckLogRepository['delete']>
+  }
+  let mockCheckTypeService: {
+    getCheckType: Mock<CheckTypeService['getCheckType']>
+  }
+
+  const vehicleId = 'vehicle-123'
+  const checkTypeDto: GetCheckTypeDto = {
+    id: '660e8400-e29b-41d4-a716-446655440000',
+    vehicleId,
+    name: 'Vidange',
+    description: null,
+    intervalDays: 7,
+    createdAt: new Date(),
+    updatedAt: new Date()
+  }
+
+  beforeEach(() => {
+    mockRepository = {
+      create: mock(() => {}) as unknown as Mock<ICheckLogRepository['create']>,
+      findById: mock(() => {}) as unknown as Mock<ICheckLogRepository['findById']>,
+      findByCheckTypeId: mock(() => {}) as unknown as Mock<
+        ICheckLogRepository['findByCheckTypeId']
+      >,
+      findByVehicleId: mock(() => {}) as unknown as Mock<ICheckLogRepository['findByVehicleId']>,
+      findMostRecentByCheckTypeIds: mock(() => {}) as unknown as Mock<
+        ICheckLogRepository['findMostRecentByCheckTypeIds']
+      >,
+      delete: mock(() => {}) as unknown as Mock<ICheckLogRepository['delete']>
+    }
+    mockCheckTypeService = {
+      getCheckType: mock(() => {}) as unknown as Mock<CheckTypeService['getCheckType']>
+    }
+    useCase = new DeleteCheckLogUseCase(
+      mockRepository as unknown as ICheckLogRepository,
+      mockCheckTypeService as unknown as CheckTypeService
+    )
+  })
+
+  describe('execute', () => {
+    it('should delete the check log when found and ownership valid', async () => {
+      const entity = makeEntity()
+
+      mockRepository.findById.mockResolvedValueOnce(entity)
+      mockCheckTypeService.getCheckType.mockResolvedValueOnce(checkTypeDto)
+      mockRepository.delete.mockResolvedValueOnce(undefined)
+
+      await useCase.execute(entity.id.value, vehicleId)
+
+      expect(mockRepository.findById).toHaveBeenCalledWith(
+        expect.objectContaining({ value: entity.id.value })
+      )
+      expect(mockCheckTypeService.getCheckType).toHaveBeenCalledWith(entity.checkTypeId, vehicleId)
+      expect(mockRepository.delete).toHaveBeenCalledWith(
+        expect.objectContaining({ value: entity.id.value })
+      )
+    })
+
+    it('should throw CheckLogNotFoundException when not found', async () => {
+      const validUUID = CheckLogIdValueObject.generate().value
+
+      mockRepository.findById.mockResolvedValueOnce(null)
+
+      await expect(useCase.execute(validUUID, vehicleId)).rejects.toThrow(
+        `Check log not found: ${validUUID}`
+      )
+      expect(mockRepository.delete).not.toHaveBeenCalled()
+    })
+
+    it('should propagate error when check type ownership fails', async () => {
+      const entity = makeEntity()
+
+      mockRepository.findById.mockResolvedValueOnce(entity)
+      mockCheckTypeService.getCheckType.mockRejectedValueOnce(new Error('Check type not found'))
+
+      await expect(useCase.execute(entity.id.value, 'wrong-vehicle')).rejects.toThrow(
+        'Check type not found'
+      )
+      expect(mockRepository.delete).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/apps/api/src/check-logs/application/use-cases/DeleteCheckLog.uc.ts
+++ b/apps/api/src/check-logs/application/use-cases/DeleteCheckLog.uc.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@nestjs/common'
+
+import { CheckLogNotFoundException } from '~/check-logs/domain/exceptions'
+import type { ICheckLogRepository } from '~/check-logs/domain/repositories'
+import { CheckLogIdValueObject } from '~/check-logs/domain/value-objects'
+import type { CheckTypeService } from '~/check-types/application/services'
+
+@Injectable()
+export class DeleteCheckLogUseCase {
+  constructor(
+    private readonly checkLogRepository: ICheckLogRepository,
+    private readonly checkTypeService: CheckTypeService
+  ) {}
+
+  async execute(id: string, vehicleId: string): Promise<void> {
+    const checkLogId = new CheckLogIdValueObject(id)
+    const entity = await this.checkLogRepository.findById(checkLogId)
+
+    if (!entity) {
+      throw new CheckLogNotFoundException(id)
+    }
+
+    await this.checkTypeService.getCheckType(entity.checkTypeId, vehicleId)
+    await this.checkLogRepository.delete(checkLogId)
+  }
+}

--- a/apps/api/src/check-logs/application/use-cases/GetCheckLog.uc.spec.ts
+++ b/apps/api/src/check-logs/application/use-cases/GetCheckLog.uc.spec.ts
@@ -1,0 +1,110 @@
+import type { Mock } from 'bun:test'
+import { beforeEach, describe, expect, it, mock } from 'bun:test'
+
+import { CheckLogEntity } from '~/check-logs/domain/entities'
+import type { ICheckLogRepository } from '~/check-logs/domain/repositories'
+import { CheckLogIdValueObject, CompletedAtValueObject } from '~/check-logs/domain/value-objects'
+import type { GetCheckTypeDto } from '~/check-types/application/dtos'
+import type { CheckTypeService } from '~/check-types/application/services'
+
+import { GetCheckLogUseCase } from './GetCheckLog.uc'
+
+const makeEntity = (vehicleCheckTypeId: string = '660e8400-e29b-41d4-a716-446655440000') =>
+  new CheckLogEntity(
+    CheckLogIdValueObject.generate(),
+    vehicleCheckTypeId,
+    new CompletedAtValueObject('2026-03-15'),
+    'All good',
+    '2026-03-22',
+    new Date(),
+    new Date()
+  )
+
+describe('GetCheckLogUseCase', () => {
+  let useCase: GetCheckLogUseCase
+  let mockRepository: {
+    create: Mock<ICheckLogRepository['create']>
+    findById: Mock<ICheckLogRepository['findById']>
+    findByCheckTypeId: Mock<ICheckLogRepository['findByCheckTypeId']>
+    findByVehicleId: Mock<ICheckLogRepository['findByVehicleId']>
+    findMostRecentByCheckTypeIds: Mock<ICheckLogRepository['findMostRecentByCheckTypeIds']>
+    delete: Mock<ICheckLogRepository['delete']>
+  }
+  let mockCheckTypeService: {
+    getCheckType: Mock<CheckTypeService['getCheckType']>
+  }
+
+  const vehicleId = 'vehicle-123'
+  const checkTypeDto: GetCheckTypeDto = {
+    id: '660e8400-e29b-41d4-a716-446655440000',
+    vehicleId,
+    name: 'Vidange',
+    description: null,
+    intervalDays: 7,
+    createdAt: new Date(),
+    updatedAt: new Date()
+  }
+
+  beforeEach(() => {
+    mockRepository = {
+      create: mock(() => {}) as unknown as Mock<ICheckLogRepository['create']>,
+      findById: mock(() => {}) as unknown as Mock<ICheckLogRepository['findById']>,
+      findByCheckTypeId: mock(() => {}) as unknown as Mock<
+        ICheckLogRepository['findByCheckTypeId']
+      >,
+      findByVehicleId: mock(() => {}) as unknown as Mock<ICheckLogRepository['findByVehicleId']>,
+      findMostRecentByCheckTypeIds: mock(() => {}) as unknown as Mock<
+        ICheckLogRepository['findMostRecentByCheckTypeIds']
+      >,
+      delete: mock(() => {}) as unknown as Mock<ICheckLogRepository['delete']>
+    }
+    mockCheckTypeService = {
+      getCheckType: mock(() => {}) as unknown as Mock<CheckTypeService['getCheckType']>
+    }
+    useCase = new GetCheckLogUseCase(
+      mockRepository as unknown as ICheckLogRepository,
+      mockCheckTypeService as unknown as CheckTypeService
+    )
+  })
+
+  describe('execute', () => {
+    it('should return the check log when found and ownership valid', async () => {
+      const entity = makeEntity()
+
+      mockRepository.findById.mockResolvedValueOnce(entity)
+      mockCheckTypeService.getCheckType.mockResolvedValueOnce(checkTypeDto)
+
+      const result = await useCase.execute(entity.id.value, vehicleId)
+
+      expect(result.id).toBe(entity.id.value)
+      expect(result.checkTypeName).toBe('Vidange')
+      expect(result.completedAt).toBe('2026-03-15')
+      expect(mockRepository.findById).toHaveBeenCalledWith(
+        expect.objectContaining({ value: entity.id.value })
+      )
+      expect(mockCheckTypeService.getCheckType).toHaveBeenCalledWith(entity.checkTypeId, vehicleId)
+    })
+
+    it('should throw CheckLogNotFoundException when not found', async () => {
+      const validUUID = CheckLogIdValueObject.generate().value
+
+      mockRepository.findById.mockResolvedValueOnce(null)
+
+      await expect(useCase.execute(validUUID, vehicleId)).rejects.toThrow(
+        `Check log not found: ${validUUID}`
+      )
+      expect(mockCheckTypeService.getCheckType).not.toHaveBeenCalled()
+    })
+
+    it('should propagate error when check type ownership fails', async () => {
+      const entity = makeEntity()
+
+      mockRepository.findById.mockResolvedValueOnce(entity)
+      mockCheckTypeService.getCheckType.mockRejectedValueOnce(new Error('Check type not found'))
+
+      await expect(useCase.execute(entity.id.value, 'wrong-vehicle')).rejects.toThrow(
+        'Check type not found'
+      )
+    })
+  })
+})

--- a/apps/api/src/check-logs/application/use-cases/GetCheckLog.uc.ts
+++ b/apps/api/src/check-logs/application/use-cases/GetCheckLog.uc.ts
@@ -1,0 +1,29 @@
+import { Injectable } from '@nestjs/common'
+
+import type { GetCheckLogDto } from '~/check-logs/application/dtos'
+import { CheckLogMapper } from '~/check-logs/application/mappers'
+import { CheckLogNotFoundException } from '~/check-logs/domain/exceptions'
+import type { ICheckLogRepository } from '~/check-logs/domain/repositories'
+import { CheckLogIdValueObject } from '~/check-logs/domain/value-objects'
+import type { CheckTypeService } from '~/check-types/application/services'
+
+@Injectable()
+export class GetCheckLogUseCase {
+  constructor(
+    private readonly checkLogRepository: ICheckLogRepository,
+    private readonly checkTypeService: CheckTypeService
+  ) {}
+
+  async execute(id: string, vehicleId: string): Promise<GetCheckLogDto> {
+    const checkLogId = new CheckLogIdValueObject(id)
+    const entity = await this.checkLogRepository.findById(checkLogId)
+
+    if (!entity) {
+      throw new CheckLogNotFoundException(id)
+    }
+
+    const checkType = await this.checkTypeService.getCheckType(entity.checkTypeId, vehicleId)
+
+    return CheckLogMapper.toGetCheckLogDto(entity, checkType.name)
+  }
+}

--- a/apps/api/src/check-logs/application/use-cases/GetCheckStatusSummary.uc.spec.ts
+++ b/apps/api/src/check-logs/application/use-cases/GetCheckStatusSummary.uc.spec.ts
@@ -1,0 +1,168 @@
+import type { Mock } from 'bun:test'
+import { beforeEach, describe, expect, it, mock } from 'bun:test'
+
+import { CheckLogEntity } from '~/check-logs/domain/entities'
+import type { ICheckLogRepository } from '~/check-logs/domain/repositories'
+import { CheckLogIdValueObject, CompletedAtValueObject } from '~/check-logs/domain/value-objects'
+import type { GetCheckTypeDto } from '~/check-types/application/dtos'
+import type { CheckTypeService } from '~/check-types/application/services'
+
+import { GetCheckStatusSummaryUseCase } from './GetCheckStatusSummary.uc'
+
+describe('GetCheckStatusSummaryUseCase', () => {
+  let useCase: GetCheckStatusSummaryUseCase
+  let mockRepository: {
+    create: Mock<ICheckLogRepository['create']>
+    findById: Mock<ICheckLogRepository['findById']>
+    findByCheckTypeId: Mock<ICheckLogRepository['findByCheckTypeId']>
+    findByVehicleId: Mock<ICheckLogRepository['findByVehicleId']>
+    findMostRecentByCheckTypeIds: Mock<ICheckLogRepository['findMostRecentByCheckTypeIds']>
+    delete: Mock<ICheckLogRepository['delete']>
+  }
+  let mockCheckTypeService: {
+    getCheckTypesByVehicle: Mock<CheckTypeService['getCheckTypesByVehicle']>
+  }
+
+  const vehicleId = 'vehicle-123'
+
+  beforeEach(() => {
+    mockRepository = {
+      create: mock(() => {}) as unknown as Mock<ICheckLogRepository['create']>,
+      findById: mock(() => {}) as unknown as Mock<ICheckLogRepository['findById']>,
+      findByCheckTypeId: mock(() => {}) as unknown as Mock<
+        ICheckLogRepository['findByCheckTypeId']
+      >,
+      findByVehicleId: mock(() => {}) as unknown as Mock<ICheckLogRepository['findByVehicleId']>,
+      findMostRecentByCheckTypeIds: mock(() => {}) as unknown as Mock<
+        ICheckLogRepository['findMostRecentByCheckTypeIds']
+      >,
+      delete: mock(() => {}) as unknown as Mock<ICheckLogRepository['delete']>
+    }
+    mockCheckTypeService = {
+      getCheckTypesByVehicle: mock(() => {}) as unknown as Mock<
+        CheckTypeService['getCheckTypesByVehicle']
+      >
+    }
+    useCase = new GetCheckStatusSummaryUseCase(
+      mockRepository as unknown as ICheckLogRepository,
+      mockCheckTypeService as unknown as CheckTypeService
+    )
+  })
+
+  describe('execute', () => {
+    it('should return status summaries for all check types', async () => {
+      const checkType1: GetCheckTypeDto = {
+        id: '660e8400-e29b-41d4-a716-446655440000',
+        vehicleId,
+        name: 'Vidange',
+        description: null,
+        intervalDays: 7,
+        createdAt: new Date(),
+        updatedAt: new Date()
+      }
+      const checkType2: GetCheckTypeDto = {
+        id: '770e8400-e29b-41d4-a716-446655440000',
+        vehicleId,
+        name: 'Pneus',
+        description: null,
+        intervalDays: 30,
+        createdAt: new Date(),
+        updatedAt: new Date()
+      }
+      const latestLog = new CheckLogEntity(
+        CheckLogIdValueObject.generate(),
+        checkType1.id,
+        new CompletedAtValueObject('2026-03-15'),
+        'All good',
+        '2026-03-22',
+        new Date(),
+        new Date()
+      )
+      const latestLogsMap = new Map<string, CheckLogEntity>([[checkType1.id, latestLog]])
+
+      mockCheckTypeService.getCheckTypesByVehicle.mockResolvedValueOnce([checkType1, checkType2])
+      mockRepository.findMostRecentByCheckTypeIds.mockResolvedValueOnce(latestLogsMap)
+
+      const result = await useCase.execute(vehicleId)
+
+      expect(result).toHaveLength(2)
+      const summary1 = result.find(s => s.checkTypeId === checkType1.id)
+      const summary2 = result.find(s => s.checkTypeId === checkType2.id)
+      expect(summary1).toBeDefined()
+      expect(summary1?.status).toBe('overdue')
+      expect(summary2).toBeDefined()
+      expect(summary2?.status).toBe('never')
+    })
+
+    it('should return all "never" when no logs exist', async () => {
+      const checkType1: GetCheckTypeDto = {
+        id: '660e8400-e29b-41d4-a716-446655440000',
+        vehicleId,
+        name: 'Vidange',
+        description: null,
+        intervalDays: 7,
+        createdAt: new Date(),
+        updatedAt: new Date()
+      }
+      const checkType2: GetCheckTypeDto = {
+        id: '770e8400-e29b-41d4-a716-446655440000',
+        vehicleId,
+        name: 'Pneus',
+        description: null,
+        intervalDays: 30,
+        createdAt: new Date(),
+        updatedAt: new Date()
+      }
+
+      mockCheckTypeService.getCheckTypesByVehicle.mockResolvedValueOnce([checkType1, checkType2])
+      mockRepository.findMostRecentByCheckTypeIds.mockResolvedValueOnce(new Map())
+
+      const result = await useCase.execute(vehicleId)
+
+      expect(result).toHaveLength(2)
+      result.forEach(summary => {
+        expect(summary.status).toBe('never')
+      })
+    })
+
+    it('should return empty array when vehicle has no check types', async () => {
+      mockCheckTypeService.getCheckTypesByVehicle.mockResolvedValueOnce([])
+      mockRepository.findMostRecentByCheckTypeIds.mockResolvedValueOnce(new Map())
+
+      const result = await useCase.execute(vehicleId)
+
+      expect(result).toEqual([])
+    })
+
+    it('should call findMostRecentByCheckTypeIds with correct IDs', async () => {
+      const checkType1: GetCheckTypeDto = {
+        id: '660e8400-e29b-41d4-a716-446655440000',
+        vehicleId,
+        name: 'Vidange',
+        description: null,
+        intervalDays: 7,
+        createdAt: new Date(),
+        updatedAt: new Date()
+      }
+      const checkType2: GetCheckTypeDto = {
+        id: '770e8400-e29b-41d4-a716-446655440000',
+        vehicleId,
+        name: 'Pneus',
+        description: null,
+        intervalDays: 30,
+        createdAt: new Date(),
+        updatedAt: new Date()
+      }
+
+      mockCheckTypeService.getCheckTypesByVehicle.mockResolvedValueOnce([checkType1, checkType2])
+      mockRepository.findMostRecentByCheckTypeIds.mockResolvedValueOnce(new Map())
+
+      await useCase.execute(vehicleId)
+
+      expect(mockRepository.findMostRecentByCheckTypeIds).toHaveBeenCalledWith([
+        checkType1.id,
+        checkType2.id
+      ])
+    })
+  })
+})

--- a/apps/api/src/check-logs/application/use-cases/GetCheckStatusSummary.uc.ts
+++ b/apps/api/src/check-logs/application/use-cases/GetCheckStatusSummary.uc.ts
@@ -14,6 +14,9 @@ export class GetCheckStatusSummaryUseCase {
 
   async execute(vehicleId: string): Promise<CheckStatusSummaryDto[]> {
     const checkTypes = await this.checkTypeService.getCheckTypesByVehicle(vehicleId)
+
+    if (checkTypes.length === 0) return []
+
     const checkTypeIds = checkTypes.map(checkType => checkType.id)
     const latestLogs = await this.checkLogRepository.findMostRecentByCheckTypeIds(checkTypeIds)
 

--- a/apps/api/src/check-logs/application/use-cases/GetCheckStatusSummary.uc.ts
+++ b/apps/api/src/check-logs/application/use-cases/GetCheckStatusSummary.uc.ts
@@ -1,0 +1,24 @@
+import { Injectable } from '@nestjs/common'
+
+import type { CheckStatusSummaryDto } from '~/check-logs/application/dtos'
+import { CheckLogMapper } from '~/check-logs/application/mappers'
+import type { ICheckLogRepository } from '~/check-logs/domain/repositories'
+import type { CheckTypeService } from '~/check-types/application/services'
+
+@Injectable()
+export class GetCheckStatusSummaryUseCase {
+  constructor(
+    private readonly checkLogRepository: ICheckLogRepository,
+    private readonly checkTypeService: CheckTypeService
+  ) {}
+
+  async execute(vehicleId: string): Promise<CheckStatusSummaryDto[]> {
+    const checkTypes = await this.checkTypeService.getCheckTypesByVehicle(vehicleId)
+    const checkTypeIds = checkTypes.map(checkType => checkType.id)
+    const latestLogs = await this.checkLogRepository.findMostRecentByCheckTypeIds(checkTypeIds)
+
+    return checkTypes.map(checkType =>
+      CheckLogMapper.toCheckStatusSummaryDto(checkType, latestLogs.get(checkType.id) ?? null)
+    )
+  }
+}

--- a/apps/api/src/check-logs/application/use-cases/ListCheckLogsByVehicle.uc.spec.ts
+++ b/apps/api/src/check-logs/application/use-cases/ListCheckLogsByVehicle.uc.spec.ts
@@ -1,0 +1,107 @@
+import type { Mock } from 'bun:test'
+import { beforeEach, describe, expect, it, mock } from 'bun:test'
+
+import { CheckLogEntity } from '~/check-logs/domain/entities'
+import type { ICheckLogRepository } from '~/check-logs/domain/repositories'
+import { CheckLogIdValueObject, CompletedAtValueObject } from '~/check-logs/domain/value-objects'
+import type { GetCheckTypeDto } from '~/check-types/application/dtos'
+import type { CheckTypeService } from '~/check-types/application/services'
+
+import { ListCheckLogsByVehicleUseCase } from './ListCheckLogsByVehicle.uc'
+
+describe('ListCheckLogsByVehicleUseCase', () => {
+  let useCase: ListCheckLogsByVehicleUseCase
+  let mockRepository: {
+    create: Mock<ICheckLogRepository['create']>
+    findById: Mock<ICheckLogRepository['findById']>
+    findByCheckTypeId: Mock<ICheckLogRepository['findByCheckTypeId']>
+    findByVehicleId: Mock<ICheckLogRepository['findByVehicleId']>
+    findMostRecentByCheckTypeIds: Mock<ICheckLogRepository['findMostRecentByCheckTypeIds']>
+    delete: Mock<ICheckLogRepository['delete']>
+  }
+  let mockCheckTypeService: {
+    getCheckTypesByVehicle: Mock<CheckTypeService['getCheckTypesByVehicle']>
+  }
+
+  const vehicleId = 'vehicle-123'
+  const checkTypeId = '660e8400-e29b-41d4-a716-446655440000'
+
+  beforeEach(() => {
+    mockRepository = {
+      create: mock(() => {}) as unknown as Mock<ICheckLogRepository['create']>,
+      findById: mock(() => {}) as unknown as Mock<ICheckLogRepository['findById']>,
+      findByCheckTypeId: mock(() => {}) as unknown as Mock<
+        ICheckLogRepository['findByCheckTypeId']
+      >,
+      findByVehicleId: mock(() => {}) as unknown as Mock<ICheckLogRepository['findByVehicleId']>,
+      findMostRecentByCheckTypeIds: mock(() => {}) as unknown as Mock<
+        ICheckLogRepository['findMostRecentByCheckTypeIds']
+      >,
+      delete: mock(() => {}) as unknown as Mock<ICheckLogRepository['delete']>
+    }
+    mockCheckTypeService = {
+      getCheckTypesByVehicle: mock(() => {}) as unknown as Mock<
+        CheckTypeService['getCheckTypesByVehicle']
+      >
+    }
+    useCase = new ListCheckLogsByVehicleUseCase(
+      mockRepository as unknown as ICheckLogRepository,
+      mockCheckTypeService as unknown as CheckTypeService
+    )
+  })
+
+  describe('execute', () => {
+    it('should return logs enriched with check type names, sorted by completedAt desc', async () => {
+      const checkTypes: GetCheckTypeDto[] = [
+        {
+          id: checkTypeId,
+          vehicleId,
+          name: 'Vidange',
+          description: null,
+          intervalDays: 7,
+          createdAt: new Date(),
+          updatedAt: new Date()
+        }
+      ]
+      const entities = [
+        new CheckLogEntity(
+          new CheckLogIdValueObject('aaa00000-0000-4000-8000-000000000001'),
+          checkTypeId,
+          new CompletedAtValueObject('2026-03-10'),
+          null,
+          '2026-03-17',
+          new Date(),
+          new Date()
+        ),
+        new CheckLogEntity(
+          new CheckLogIdValueObject('aaa00000-0000-4000-8000-000000000002'),
+          checkTypeId,
+          new CompletedAtValueObject('2026-03-15'),
+          'Recent',
+          '2026-03-22',
+          new Date(),
+          new Date()
+        )
+      ]
+
+      mockCheckTypeService.getCheckTypesByVehicle.mockResolvedValueOnce(checkTypes)
+      mockRepository.findByVehicleId.mockResolvedValueOnce(entities)
+
+      const result = await useCase.execute(vehicleId)
+
+      expect(result).toHaveLength(2)
+      expect(result[0].completedAt).toBe('2026-03-15')
+      expect(result[1].completedAt).toBe('2026-03-10')
+      expect(result[0].checkTypeName).toBe('Vidange')
+    })
+
+    it('should return empty array when no logs exist', async () => {
+      mockCheckTypeService.getCheckTypesByVehicle.mockResolvedValueOnce([])
+      mockRepository.findByVehicleId.mockResolvedValueOnce([])
+
+      const result = await useCase.execute(vehicleId)
+
+      expect(result).toEqual([])
+    })
+  })
+})

--- a/apps/api/src/check-logs/application/use-cases/ListCheckLogsByVehicle.uc.ts
+++ b/apps/api/src/check-logs/application/use-cases/ListCheckLogsByVehicle.uc.ts
@@ -1,0 +1,25 @@
+import { Injectable } from '@nestjs/common'
+
+import type { GetCheckLogDto } from '~/check-logs/application/dtos'
+import { CheckLogMapper } from '~/check-logs/application/mappers'
+import type { ICheckLogRepository } from '~/check-logs/domain/repositories'
+import type { CheckTypeService } from '~/check-types/application/services'
+
+@Injectable()
+export class ListCheckLogsByVehicleUseCase {
+  constructor(
+    private readonly checkLogRepository: ICheckLogRepository,
+    private readonly checkTypeService: CheckTypeService
+  ) {}
+
+  async execute(vehicleId: string): Promise<GetCheckLogDto[]> {
+    const checkTypes = await this.checkTypeService.getCheckTypesByVehicle(vehicleId)
+    const nameMap = new Map(checkTypes.map(ct => [ct.id, ct.name]))
+
+    const logs = await this.checkLogRepository.findByVehicleId(vehicleId)
+
+    return logs
+      .map(log => CheckLogMapper.toGetCheckLogDto(log, nameMap.get(log.checkTypeId) ?? ''))
+      .sort((a, b) => (b.completedAt > a.completedAt ? 1 : -1))
+  }
+}

--- a/apps/api/src/check-logs/application/use-cases/ListCheckLogsByVehicle.uc.ts
+++ b/apps/api/src/check-logs/application/use-cases/ListCheckLogsByVehicle.uc.ts
@@ -20,6 +20,10 @@ export class ListCheckLogsByVehicleUseCase {
 
     return logs
       .map(log => CheckLogMapper.toGetCheckLogDto(log, nameMap.get(log.checkTypeId) ?? ''))
-      .sort((a, b) => (b.completedAt > a.completedAt ? 1 : -1))
+      .sort((a, b) => {
+        if (a.completedAt === b.completedAt) return 0
+
+        return a.completedAt > b.completedAt ? -1 : 1
+      })
   }
 }

--- a/apps/api/src/check-logs/application/use-cases/index.ts
+++ b/apps/api/src/check-logs/application/use-cases/index.ts
@@ -1,0 +1,5 @@
+export { CreateCheckLogUseCase } from './CreateCheckLog.uc'
+export { DeleteCheckLogUseCase } from './DeleteCheckLog.uc'
+export { GetCheckLogUseCase } from './GetCheckLog.uc'
+export { GetCheckStatusSummaryUseCase } from './GetCheckStatusSummary.uc'
+export { ListCheckLogsByVehicleUseCase } from './ListCheckLogsByVehicle.uc'

--- a/apps/api/src/check-logs/infrastructure/controllers/CheckLog.controller.spec.ts
+++ b/apps/api/src/check-logs/infrastructure/controllers/CheckLog.controller.spec.ts
@@ -1,0 +1,208 @@
+import { Test } from '@nestjs/testing'
+import type { Mock } from 'bun:test'
+import { beforeEach, describe, expect, it, mock } from 'bun:test'
+
+import type { AuthSession } from '~/auth/domain/types'
+import { CreateCheckLogDto, GetCheckLogDto } from '~/check-logs/application/dtos'
+import { CheckLogService } from '~/check-logs/application/services'
+import { GetVehicleDto } from '~/vehicles/application/dtos'
+import { VehicleService } from '~/vehicles/application/services'
+
+import { CheckLogController } from './CheckLog.controller'
+
+describe('CheckLogController', () => {
+  let controller: CheckLogController
+  let mockCheckLogService: {
+    createCheckLog: Mock<typeof CheckLogService.prototype.createCheckLog>
+    listCheckLogsByVehicle: Mock<typeof CheckLogService.prototype.listCheckLogsByVehicle>
+    getCheckLog: Mock<typeof CheckLogService.prototype.getCheckLog>
+    deleteCheckLog: Mock<typeof CheckLogService.prototype.deleteCheckLog>
+  }
+  let mockVehicleService: {
+    getVehicleByUser: Mock<typeof VehicleService.prototype.getVehicleByUser>
+  }
+
+  const vehicleId = '123e4567-e89b-12d3-a456-426614174000'
+  const userId = '123e4567-e89b-12d3-a456-426614174001'
+
+  const createMockSession = (uid: string): AuthSession => ({
+    session: { id: 'session-id', userId: uid, expiresAt: new Date() },
+    user: {
+      id: uid,
+      email: 'test@example.com',
+      emailVerified: true,
+      username: 'testuser',
+      firstName: 'Test',
+      lastName: 'User',
+      role: 'user',
+      banned: false,
+      banReason: null,
+      banExpires: null,
+      createdAt: new Date(),
+      updatedAt: new Date()
+    }
+  })
+
+  const createMockVehicleDto = (overrides = {}): GetVehicleDto => {
+    const dto = new GetVehicleDto()
+    Object.assign(dto, {
+      id: vehicleId,
+      userId,
+      make: 'Toyota',
+      model: 'Camry',
+      year: 2020,
+      engineType: 'V6',
+      fuelType: 'GASOLINE',
+      vin: null,
+      licensePlate: 'ABC123',
+      purchaseDate: new Date('2025-01-01'),
+      mileage: 15000,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      ...overrides
+    })
+    return dto
+  }
+
+  const createMockGetCheckLogDto = (overrides = {}): GetCheckLogDto => {
+    const dto = new GetCheckLogDto()
+    Object.assign(dto, {
+      id: '123e4567-e89b-12d3-a456-426614174010',
+      checkTypeId: '660e8400-e29b-41d4-a716-446655440000',
+      checkTypeName: 'Vidange',
+      completedAt: '2026-03-15',
+      notes: 'All good',
+      nextDueAt: '2026-03-22',
+      createdAt: new Date(),
+      ...overrides
+    })
+    return dto
+  }
+
+  beforeEach(async () => {
+    mockCheckLogService = {
+      createCheckLog: mock(() => {}) as unknown as Mock<
+        typeof CheckLogService.prototype.createCheckLog
+      >,
+      listCheckLogsByVehicle: mock(() => {}) as unknown as Mock<
+        typeof CheckLogService.prototype.listCheckLogsByVehicle
+      >,
+      getCheckLog: mock(() => {}) as unknown as Mock<typeof CheckLogService.prototype.getCheckLog>,
+      deleteCheckLog: mock(() => {}) as unknown as Mock<
+        typeof CheckLogService.prototype.deleteCheckLog
+      >
+    }
+
+    mockVehicleService = {
+      getVehicleByUser: mock(() => {}) as unknown as Mock<
+        typeof VehicleService.prototype.getVehicleByUser
+      >
+    }
+
+    const module = await Test.createTestingModule({
+      controllers: [CheckLogController],
+      providers: [
+        { provide: CheckLogService, useValue: mockCheckLogService },
+        { provide: VehicleService, useValue: mockVehicleService }
+      ]
+    }).compile()
+
+    controller = module.get<CheckLogController>(CheckLogController)
+
+    mockCheckLogService.createCheckLog.mockClear()
+    mockCheckLogService.listCheckLogsByVehicle.mockClear()
+    mockCheckLogService.getCheckLog.mockClear()
+    mockCheckLogService.deleteCheckLog.mockClear()
+    mockVehicleService.getVehicleByUser.mockClear()
+  })
+
+  describe('create', () => {
+    it('should create a check log for the vehicle', async () => {
+      const createDto = new CreateCheckLogDto()
+      const expectedVehicle = createMockVehicleDto()
+      const expectedCheckLog = createMockGetCheckLogDto()
+      const session = createMockSession(userId)
+
+      mockVehicleService.getVehicleByUser.mockResolvedValue(expectedVehicle)
+      mockCheckLogService.createCheckLog.mockResolvedValue(expectedCheckLog)
+
+      const result = await controller.create(session, vehicleId, createDto)
+
+      expect(mockVehicleService.getVehicleByUser).toHaveBeenCalledWith(userId)
+      expect(mockCheckLogService.createCheckLog).toHaveBeenCalledWith(createDto, vehicleId)
+      expect(result).toEqual(expectedCheckLog)
+    })
+  })
+
+  describe('getByVehicle', () => {
+    it('should return all check logs for the vehicle', async () => {
+      const expectedVehicle = createMockVehicleDto()
+      const expectedCheckLogs = [createMockGetCheckLogDto()]
+      const session = createMockSession(userId)
+
+      mockVehicleService.getVehicleByUser.mockResolvedValue(expectedVehicle)
+      mockCheckLogService.listCheckLogsByVehicle.mockResolvedValue(expectedCheckLogs)
+
+      const result = await controller.getByVehicle(session, vehicleId)
+
+      expect(mockVehicleService.getVehicleByUser).toHaveBeenCalledWith(userId)
+      expect(mockCheckLogService.listCheckLogsByVehicle).toHaveBeenCalledWith(vehicleId)
+      expect(result).toEqual(expectedCheckLogs)
+    })
+  })
+
+  describe('getOne', () => {
+    it('should return a single check log', async () => {
+      const expectedVehicle = createMockVehicleDto()
+      const expectedCheckLog = createMockGetCheckLogDto()
+      const session = createMockSession(userId)
+
+      mockVehicleService.getVehicleByUser.mockResolvedValue(expectedVehicle)
+      mockCheckLogService.getCheckLog.mockResolvedValue(expectedCheckLog)
+
+      const result = await controller.getOne(session, vehicleId, expectedCheckLog.id)
+
+      expect(mockVehicleService.getVehicleByUser).toHaveBeenCalledWith(userId)
+      expect(mockCheckLogService.getCheckLog).toHaveBeenCalledWith(expectedCheckLog.id, vehicleId)
+      expect(result).toEqual(expectedCheckLog)
+    })
+  })
+
+  describe('delete', () => {
+    it('should delete a check log', async () => {
+      const expectedVehicle = createMockVehicleDto()
+      const session = createMockSession(userId)
+
+      mockVehicleService.getVehicleByUser.mockResolvedValue(expectedVehicle)
+      mockCheckLogService.deleteCheckLog.mockResolvedValue(undefined)
+
+      await controller.delete(session, vehicleId, 'some-id')
+
+      expect(mockVehicleService.getVehicleByUser).toHaveBeenCalledWith(userId)
+      expect(mockCheckLogService.deleteCheckLog).toHaveBeenCalledWith('some-id', vehicleId)
+    })
+  })
+
+  describe('verifyVehicleOwnership', () => {
+    it('should throw VehicleNotFoundException when user has no vehicle', async () => {
+      const session = createMockSession(userId)
+
+      mockVehicleService.getVehicleByUser.mockResolvedValue(null)
+
+      await expect(controller.getByVehicle(session, vehicleId)).rejects.toThrow(
+        `Vehicle not found: ${vehicleId}`
+      )
+    })
+
+    it('should throw VehicleNotFoundException when vehicle ID does not match', async () => {
+      const session = createMockSession(userId)
+      const wrongVehicle = createMockVehicleDto({ id: 'different-vehicle-id' })
+
+      mockVehicleService.getVehicleByUser.mockResolvedValue(wrongVehicle)
+
+      await expect(controller.getByVehicle(session, vehicleId)).rejects.toThrow(
+        `Vehicle not found: ${vehicleId}`
+      )
+    })
+  })
+})

--- a/apps/api/src/check-logs/infrastructure/controllers/CheckLog.controller.ts
+++ b/apps/api/src/check-logs/infrastructure/controllers/CheckLog.controller.ts
@@ -1,0 +1,67 @@
+import { Body, Controller, Delete, Get, Param, Post } from '@nestjs/common'
+import { Session } from '@thallesp/nestjs-better-auth'
+
+import type { AuthSession } from '~/auth/domain/types'
+import type { CreateCheckLogDto, GetCheckLogDto } from '~/check-logs/application/dtos'
+import { CheckLogService } from '~/check-logs/application/services'
+import { VehicleService } from '~/vehicles/application/services'
+import { VehicleNotFoundException } from '~/vehicles/domain/exceptions'
+
+@Controller('vehicles/:vehicleId/check-logs')
+export class CheckLogController {
+  constructor(
+    private readonly checkLogService: CheckLogService,
+    private readonly vehicleService: VehicleService
+  ) {}
+
+  @Post()
+  async create(
+    @Session() session: AuthSession,
+    @Param('vehicleId') vehicleId: string,
+    @Body() createDto: CreateCheckLogDto
+  ): Promise<GetCheckLogDto> {
+    await this.verifyVehicleOwnership(vehicleId, session.user.id)
+
+    return this.checkLogService.createCheckLog(createDto, vehicleId)
+  }
+
+  @Get()
+  async getByVehicle(
+    @Session() session: AuthSession,
+    @Param('vehicleId') vehicleId: string
+  ): Promise<GetCheckLogDto[]> {
+    await this.verifyVehicleOwnership(vehicleId, session.user.id)
+
+    return this.checkLogService.listCheckLogsByVehicle(vehicleId)
+  }
+
+  @Get(':id')
+  async getOne(
+    @Session() session: AuthSession,
+    @Param('vehicleId') vehicleId: string,
+    @Param('id') id: string
+  ): Promise<GetCheckLogDto> {
+    await this.verifyVehicleOwnership(vehicleId, session.user.id)
+
+    return this.checkLogService.getCheckLog(id, vehicleId)
+  }
+
+  @Delete(':id')
+  async delete(
+    @Session() session: AuthSession,
+    @Param('vehicleId') vehicleId: string,
+    @Param('id') id: string
+  ): Promise<void> {
+    await this.verifyVehicleOwnership(vehicleId, session.user.id)
+
+    return this.checkLogService.deleteCheckLog(id, vehicleId)
+  }
+
+  private async verifyVehicleOwnership(vehicleId: string, userId: string): Promise<void> {
+    const vehicle = await this.vehicleService.getVehicleByUser(userId)
+
+    if (!vehicle || vehicle.id !== vehicleId) {
+      throw new VehicleNotFoundException(vehicleId)
+    }
+  }
+}

--- a/apps/api/src/check-logs/infrastructure/controllers/CheckStatus.controller.spec.ts
+++ b/apps/api/src/check-logs/infrastructure/controllers/CheckStatus.controller.spec.ts
@@ -1,0 +1,128 @@
+import { Test } from '@nestjs/testing'
+import type { Mock } from 'bun:test'
+import { beforeEach, describe, expect, it, mock } from 'bun:test'
+
+import type { AuthSession } from '~/auth/domain/types'
+import { CheckStatusSummaryDto } from '~/check-logs/application/dtos'
+import { CheckLogService } from '~/check-logs/application/services'
+import { GetVehicleDto } from '~/vehicles/application/dtos'
+import { VehicleService } from '~/vehicles/application/services'
+
+import { CheckStatusController } from './CheckStatus.controller'
+
+describe('CheckStatusController', () => {
+  let controller: CheckStatusController
+  let mockCheckLogService: {
+    getCheckStatusSummary: Mock<typeof CheckLogService.prototype.getCheckStatusSummary>
+  }
+  let mockVehicleService: {
+    getVehicleByUser: Mock<typeof VehicleService.prototype.getVehicleByUser>
+  }
+
+  const vehicleId = '123e4567-e89b-12d3-a456-426614174000'
+  const userId = '123e4567-e89b-12d3-a456-426614174001'
+
+  const createMockSession = (uid: string): AuthSession => ({
+    session: { id: 'session-id', userId: uid, expiresAt: new Date() },
+    user: {
+      id: uid,
+      email: 'test@example.com',
+      emailVerified: true,
+      username: 'testuser',
+      firstName: 'Test',
+      lastName: 'User',
+      role: 'user',
+      banned: false,
+      banReason: null,
+      banExpires: null,
+      createdAt: new Date(),
+      updatedAt: new Date()
+    }
+  })
+
+  const createMockVehicleDto = (overrides = {}): GetVehicleDto => {
+    const dto = new GetVehicleDto()
+    Object.assign(dto, {
+      id: vehicleId,
+      userId,
+      make: 'Toyota',
+      model: 'Camry',
+      year: 2020,
+      engineType: 'V6',
+      fuelType: 'GASOLINE',
+      vin: null,
+      licensePlate: 'ABC123',
+      purchaseDate: new Date('2025-01-01'),
+      mileage: 15000,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      ...overrides
+    })
+    return dto
+  }
+
+  beforeEach(async () => {
+    mockCheckLogService = {
+      getCheckStatusSummary: mock(() => {}) as unknown as Mock<
+        typeof CheckLogService.prototype.getCheckStatusSummary
+      >
+    }
+
+    mockVehicleService = {
+      getVehicleByUser: mock(() => {}) as unknown as Mock<
+        typeof VehicleService.prototype.getVehicleByUser
+      >
+    }
+
+    const module = await Test.createTestingModule({
+      controllers: [CheckStatusController],
+      providers: [
+        { provide: CheckLogService, useValue: mockCheckLogService },
+        { provide: VehicleService, useValue: mockVehicleService }
+      ]
+    }).compile()
+
+    controller = module.get<CheckStatusController>(CheckStatusController)
+
+    mockCheckLogService.getCheckStatusSummary.mockClear()
+    mockVehicleService.getVehicleByUser.mockClear()
+  })
+
+  describe('getSummary', () => {
+    it('should return check status summaries for the vehicle', async () => {
+      const expectedVehicle = createMockVehicleDto()
+      const summaries = [
+        Object.assign(new CheckStatusSummaryDto(), {
+          checkTypeId: '660e8400-e29b-41d4-a716-446655440000',
+          checkTypeName: 'Vidange',
+          intervalDays: 7,
+          lastCompletedAt: '2026-03-15',
+          nextDueAt: '2026-03-22',
+          status: 'on-time'
+        })
+      ]
+      const session = createMockSession(userId)
+
+      mockVehicleService.getVehicleByUser.mockResolvedValue(expectedVehicle)
+      mockCheckLogService.getCheckStatusSummary.mockResolvedValue(summaries)
+
+      const result = await controller.getSummary(session, vehicleId)
+
+      expect(mockVehicleService.getVehicleByUser).toHaveBeenCalledWith(userId)
+      expect(mockCheckLogService.getCheckStatusSummary).toHaveBeenCalledWith(vehicleId)
+      expect(result).toEqual(summaries)
+    })
+  })
+
+  describe('verifyVehicleOwnership', () => {
+    it('should throw VehicleNotFoundException when user has no vehicle', async () => {
+      const session = createMockSession(userId)
+
+      mockVehicleService.getVehicleByUser.mockResolvedValue(null)
+
+      await expect(controller.getSummary(session, vehicleId)).rejects.toThrow(
+        `Vehicle not found: ${vehicleId}`
+      )
+    })
+  })
+})

--- a/apps/api/src/check-logs/infrastructure/controllers/CheckStatus.controller.ts
+++ b/apps/api/src/check-logs/infrastructure/controllers/CheckStatus.controller.ts
@@ -1,0 +1,34 @@
+import { Controller, Get, Param } from '@nestjs/common'
+import { Session } from '@thallesp/nestjs-better-auth'
+
+import type { AuthSession } from '~/auth/domain/types'
+import type { CheckStatusSummaryDto } from '~/check-logs/application/dtos'
+import { CheckLogService } from '~/check-logs/application/services'
+import { VehicleService } from '~/vehicles/application/services'
+import { VehicleNotFoundException } from '~/vehicles/domain/exceptions'
+
+@Controller('vehicles/:vehicleId/check-status')
+export class CheckStatusController {
+  constructor(
+    private readonly checkLogService: CheckLogService,
+    private readonly vehicleService: VehicleService
+  ) {}
+
+  @Get()
+  async getSummary(
+    @Session() session: AuthSession,
+    @Param('vehicleId') vehicleId: string
+  ): Promise<CheckStatusSummaryDto[]> {
+    await this.verifyVehicleOwnership(vehicleId, session.user.id)
+
+    return this.checkLogService.getCheckStatusSummary(vehicleId)
+  }
+
+  private async verifyVehicleOwnership(vehicleId: string, userId: string): Promise<void> {
+    const vehicle = await this.vehicleService.getVehicleByUser(userId)
+
+    if (!vehicle || vehicle.id !== vehicleId) {
+      throw new VehicleNotFoundException(vehicleId)
+    }
+  }
+}

--- a/apps/api/src/check-logs/infrastructure/controllers/index.ts
+++ b/apps/api/src/check-logs/infrastructure/controllers/index.ts
@@ -1,0 +1,2 @@
+export { CheckLogController } from './CheckLog.controller'
+export { CheckStatusController } from './CheckStatus.controller'

--- a/apps/api/src/check-logs/infrastructure/mappers/CheckLogInfra.mapper.spec.ts
+++ b/apps/api/src/check-logs/infrastructure/mappers/CheckLogInfra.mapper.spec.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'bun:test'
+
+import { CheckLogEntity } from '~/check-logs/domain/entities'
+import { CheckLogIdValueObject, CompletedAtValueObject } from '~/check-logs/domain/value-objects'
+
+import { CheckLogInfrastructureMapper } from './CheckLogInfra.mapper'
+
+describe('CheckLogInfrastructureMapper', () => {
+  describe('toDomain', () => {
+    it('should map PrismaCheckLog to CheckLogEntity with all fields', () => {
+      const prismaCheckLog = {
+        id: CheckLogIdValueObject.generate().value,
+        checkTypeId: '660e8400-e29b-41d4-a716-446655440000',
+        completedAt: '2026-03-15',
+        notes: 'All good',
+        nextDueAt: '2026-03-22',
+        createdAt: new Date('2026-03-15T10:00:00Z'),
+        updatedAt: new Date('2026-03-15T10:00:00Z')
+      }
+
+      const result = CheckLogInfrastructureMapper.toDomain(prismaCheckLog)
+
+      expect(result).toBeInstanceOf(CheckLogEntity)
+      expect(result.id).toBeInstanceOf(CheckLogIdValueObject)
+      expect(result.id.value).toBe(prismaCheckLog.id)
+      expect(result.checkTypeId).toBe(prismaCheckLog.checkTypeId)
+      expect(result.completedAt).toBeInstanceOf(CompletedAtValueObject)
+      expect(result.completedAt.value).toBe(prismaCheckLog.completedAt)
+      expect(result.notes).toBe(prismaCheckLog.notes)
+      expect(result.nextDueAt).toBe(prismaCheckLog.nextDueAt)
+      expect(result.createdAt).toEqual(prismaCheckLog.createdAt)
+      expect(result.updatedAt).toEqual(prismaCheckLog.updatedAt)
+    })
+
+    it('should map PrismaCheckLog with null notes', () => {
+      const prismaCheckLog = {
+        id: CheckLogIdValueObject.generate().value,
+        checkTypeId: '660e8400-e29b-41d4-a716-446655440000',
+        completedAt: '2026-03-15',
+        notes: null,
+        nextDueAt: '2026-03-22',
+        createdAt: new Date('2026-03-15T10:00:00Z'),
+        updatedAt: new Date('2026-03-15T10:00:00Z')
+      }
+
+      const result = CheckLogInfrastructureMapper.toDomain(prismaCheckLog)
+
+      expect(result.notes).toBeNull()
+    })
+  })
+
+  describe('toPrisma', () => {
+    it('should map CheckLogEntity to Prisma data with all fields', () => {
+      const entity = new CheckLogEntity(
+        CheckLogIdValueObject.generate(),
+        '660e8400-e29b-41d4-a716-446655440000',
+        new CompletedAtValueObject('2026-03-15'),
+        'All good',
+        '2026-03-22',
+        new Date('2026-03-15T10:00:00Z'),
+        new Date('2026-03-15T10:00:00Z')
+      )
+
+      const result = CheckLogInfrastructureMapper.toPrisma(entity)
+
+      expect(result).toEqual({
+        id: entity.id.value,
+        checkTypeId: entity.checkTypeId,
+        completedAt: entity.completedAt.value,
+        notes: entity.notes,
+        nextDueAt: entity.nextDueAt,
+        createdAt: entity.createdAt,
+        updatedAt: entity.updatedAt
+      })
+    })
+
+    it('should map CheckLogEntity with null notes', () => {
+      const entity = new CheckLogEntity(
+        CheckLogIdValueObject.generate(),
+        '660e8400-e29b-41d4-a716-446655440000',
+        new CompletedAtValueObject('2026-03-15'),
+        null,
+        '2026-03-22',
+        new Date('2026-03-15T10:00:00Z'),
+        new Date('2026-03-15T10:00:00Z')
+      )
+
+      const result = CheckLogInfrastructureMapper.toPrisma(entity)
+
+      expect(result.notes).toBeNull()
+    })
+  })
+})

--- a/apps/api/src/check-logs/infrastructure/mappers/CheckLogInfra.mapper.ts
+++ b/apps/api/src/check-logs/infrastructure/mappers/CheckLogInfra.mapper.ts
@@ -1,0 +1,30 @@
+import type { CheckLog as PrismaCheckLog } from '@generated'
+
+import { CheckLogEntity } from '~/check-logs/domain/entities'
+import { CheckLogIdValueObject, CompletedAtValueObject } from '~/check-logs/domain/value-objects'
+
+export class CheckLogInfrastructureMapper {
+  static toDomain(prismaCheckLog: PrismaCheckLog): CheckLogEntity {
+    return new CheckLogEntity(
+      new CheckLogIdValueObject(prismaCheckLog.id),
+      prismaCheckLog.checkTypeId,
+      new CompletedAtValueObject(prismaCheckLog.completedAt),
+      prismaCheckLog.notes ?? null,
+      prismaCheckLog.nextDueAt,
+      prismaCheckLog.createdAt,
+      prismaCheckLog.updatedAt
+    )
+  }
+
+  static toPrisma(entity: CheckLogEntity): Omit<PrismaCheckLog, 'checkType'> {
+    return {
+      id: entity.id.value,
+      checkTypeId: entity.checkTypeId,
+      completedAt: entity.completedAt.value,
+      notes: entity.notes ?? null,
+      nextDueAt: entity.nextDueAt,
+      createdAt: entity.createdAt,
+      updatedAt: entity.updatedAt
+    }
+  }
+}

--- a/apps/api/src/check-logs/infrastructure/mappers/index.ts
+++ b/apps/api/src/check-logs/infrastructure/mappers/index.ts
@@ -1,0 +1,1 @@
+export { CheckLogInfrastructureMapper } from './CheckLogInfra.mapper'

--- a/apps/api/src/check-logs/infrastructure/repositories/PrismaCheckLog.repository.spec.ts
+++ b/apps/api/src/check-logs/infrastructure/repositories/PrismaCheckLog.repository.spec.ts
@@ -1,0 +1,214 @@
+import type { Mock } from 'bun:test'
+import { beforeEach, describe, expect, it, mock } from 'bun:test'
+
+import { Prisma } from '@generated'
+
+import { CheckLogEntity } from '~/check-logs/domain/entities'
+import { CheckLogNotFoundException } from '~/check-logs/domain/exceptions'
+import { CheckLogIdValueObject, CompletedAtValueObject } from '~/check-logs/domain/value-objects'
+import type { PrismaProvider } from '~/shared/infrastructure/database'
+
+import { CheckLogInfrastructureMapper } from '../mappers'
+
+import { PrismaCheckLogRepository } from './PrismaCheckLog.repository'
+
+describe('PrismaCheckLogRepository', () => {
+  let repository: PrismaCheckLogRepository
+  let mockPrismaService: {
+    checkLog: {
+      create: Mock<PrismaProvider['checkLog']['create']>
+      findUnique: Mock<PrismaProvider['checkLog']['findUnique']>
+      findMany: Mock<PrismaProvider['checkLog']['findMany']>
+      delete: Mock<PrismaProvider['checkLog']['delete']>
+    }
+  }
+
+  const createMockPrismaCheckLog = (overrides = {}) => ({
+    id: '123e4567-e89b-12d3-a456-426614174000',
+    checkTypeId: '660e8400-e29b-41d4-a716-446655440000',
+    completedAt: '2026-03-15',
+    notes: 'All good',
+    nextDueAt: '2026-03-22',
+    createdAt: new Date('2026-03-15T10:00:00Z'),
+    updatedAt: new Date('2026-03-15T10:00:00Z'),
+    ...overrides
+  })
+
+  const createMockCheckLogEntity = () =>
+    new CheckLogEntity(
+      new CheckLogIdValueObject('123e4567-e89b-12d3-a456-426614174000'),
+      '660e8400-e29b-41d4-a716-446655440000',
+      new CompletedAtValueObject('2026-03-15'),
+      'All good',
+      '2026-03-22',
+      new Date('2026-03-15T10:00:00Z'),
+      new Date('2026-03-15T10:00:00Z')
+    )
+
+  beforeEach(() => {
+    mockPrismaService = {
+      checkLog: {
+        create: mock(() => {}) as unknown as Mock<PrismaProvider['checkLog']['create']>,
+        findUnique: mock(() => {}) as unknown as Mock<PrismaProvider['checkLog']['findUnique']>,
+        findMany: mock(() => {}) as unknown as Mock<PrismaProvider['checkLog']['findMany']>,
+        delete: mock(() => {}) as unknown as Mock<PrismaProvider['checkLog']['delete']>
+      }
+    }
+
+    repository = new PrismaCheckLogRepository(mockPrismaService as unknown as PrismaProvider)
+  })
+
+  describe('create', () => {
+    it('should create check log and return domain entity', async () => {
+      const checkLogEntity = createMockCheckLogEntity()
+      const prismaRecord = createMockPrismaCheckLog()
+
+      mockPrismaService.checkLog.create.mockResolvedValue(prismaRecord)
+
+      const result = await repository.create(checkLogEntity)
+
+      expect(mockPrismaService.checkLog.create).toHaveBeenCalledWith({
+        data: CheckLogInfrastructureMapper.toPrisma(checkLogEntity)
+      })
+      expect(result).toEqual(checkLogEntity)
+    })
+  })
+
+  describe('findById', () => {
+    it('should find check log by id and return domain entity', async () => {
+      const checkLogEntity = createMockCheckLogEntity()
+      const prismaRecord = createMockPrismaCheckLog()
+
+      mockPrismaService.checkLog.findUnique.mockResolvedValue(prismaRecord)
+
+      const result = await repository.findById(checkLogEntity.id)
+
+      expect(mockPrismaService.checkLog.findUnique).toHaveBeenCalledWith({
+        where: { id: checkLogEntity.id.value }
+      })
+      expect(result).toEqual(checkLogEntity)
+    })
+
+    it('should return null when check log not found', async () => {
+      mockPrismaService.checkLog.findUnique.mockResolvedValue(null)
+
+      const result = await repository.findById(
+        new CheckLogIdValueObject('123e4567-e89b-12d3-a456-426614174000')
+      )
+
+      expect(mockPrismaService.checkLog.findUnique).toHaveBeenCalledWith({
+        where: { id: '123e4567-e89b-12d3-a456-426614174000' }
+      })
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('findByCheckTypeId', () => {
+    it('should find all logs for a check type', async () => {
+      const checkLogEntity = createMockCheckLogEntity()
+      const prismaRecord = createMockPrismaCheckLog()
+
+      mockPrismaService.checkLog.findMany.mockResolvedValue([prismaRecord])
+
+      const result = await repository.findByCheckTypeId(checkLogEntity.checkTypeId)
+
+      expect(mockPrismaService.checkLog.findMany).toHaveBeenCalledWith({
+        where: { checkTypeId: checkLogEntity.checkTypeId }
+      })
+      expect(result).toEqual([checkLogEntity])
+    })
+  })
+
+  describe('findByVehicleId', () => {
+    it('should find all logs for a vehicle using relation filter', async () => {
+      const vehicleId = '550e8400-e29b-41d4-a716-446655440000'
+      const checkLogEntity = createMockCheckLogEntity()
+      const prismaRecord = createMockPrismaCheckLog()
+
+      mockPrismaService.checkLog.findMany.mockResolvedValue([prismaRecord])
+
+      const result = await repository.findByVehicleId(vehicleId)
+
+      expect(mockPrismaService.checkLog.findMany).toHaveBeenCalledWith({
+        where: { checkType: { vehicleId } }
+      })
+      expect(result).toEqual([checkLogEntity])
+    })
+  })
+
+  describe('findMostRecentByCheckTypeIds', () => {
+    it('should return a Map with most recent log per check type', async () => {
+      const checkTypeId1 = '660e8400-e29b-41d4-a716-446655440000'
+      const checkTypeId2 = '770e8400-e29b-41d4-a716-446655440000'
+
+      const log1 = createMockPrismaCheckLog({
+        id: 'aaa00000-0000-4000-8000-000000000001',
+        checkTypeId: checkTypeId1,
+        completedAt: '2026-03-15'
+      })
+      const log2 = createMockPrismaCheckLog({
+        id: 'aaa00000-0000-4000-8000-000000000002',
+        checkTypeId: checkTypeId1,
+        completedAt: '2026-03-20'
+      })
+      const log3 = createMockPrismaCheckLog({
+        id: 'aaa00000-0000-4000-8000-000000000003',
+        checkTypeId: checkTypeId2,
+        completedAt: '2026-03-18'
+      })
+
+      mockPrismaService.checkLog.findMany.mockResolvedValue([log2, log1, log3]) // unordered
+
+      const result = await repository.findMostRecentByCheckTypeIds([checkTypeId1, checkTypeId2])
+
+      expect(mockPrismaService.checkLog.findMany).toHaveBeenCalledWith({
+        where: { checkTypeId: { in: [checkTypeId1, checkTypeId2] } },
+        orderBy: { completedAt: 'desc' }
+      })
+
+      expect(result.size).toBe(2)
+      expect(result.get(checkTypeId1)).toEqual(CheckLogInfrastructureMapper.toDomain(log2)) // most recent for checkTypeId1
+      expect(result.get(checkTypeId2)).toEqual(CheckLogInfrastructureMapper.toDomain(log3))
+    })
+
+    it('should return empty Map when no logs exist', async () => {
+      mockPrismaService.checkLog.findMany.mockResolvedValue([])
+
+      const result = await repository.findMostRecentByCheckTypeIds([
+        '123e4567-e89b-12d3-a456-426614174000'
+      ])
+
+      expect(mockPrismaService.checkLog.findMany).toHaveBeenCalledWith({
+        where: { checkTypeId: { in: ['123e4567-e89b-12d3-a456-426614174000'] } },
+        orderBy: { completedAt: 'desc' }
+      })
+
+      expect(result.size).toBe(0)
+    })
+  })
+
+  describe('delete', () => {
+    it('should delete check log by id', async () => {
+      const checkLogId = new CheckLogIdValueObject('123e4567-e89b-12d3-a456-426614174000')
+
+      await repository.delete(checkLogId)
+
+      expect(mockPrismaService.checkLog.delete).toHaveBeenCalledWith({
+        where: { id: checkLogId.value }
+      })
+    })
+
+    it('should throw CheckLogNotFoundException on P2025', async () => {
+      const checkLogId = new CheckLogIdValueObject('123e4567-e89b-12d3-a456-426614174000')
+
+      mockPrismaService.checkLog.delete.mockRejectedValueOnce(
+        new Prisma.PrismaClientKnownRequestError('Record not found', {
+          code: 'P2025',
+          clientVersion: '7.0.0'
+        })
+      )
+
+      await expect(repository.delete(checkLogId)).rejects.toThrow(CheckLogNotFoundException)
+    })
+  })
+})

--- a/apps/api/src/check-logs/infrastructure/repositories/PrismaCheckLog.repository.ts
+++ b/apps/api/src/check-logs/infrastructure/repositories/PrismaCheckLog.repository.ts
@@ -1,0 +1,81 @@
+import { Injectable } from '@nestjs/common'
+
+import { Prisma } from '@generated'
+
+import type { CheckLogEntity } from '~/check-logs/domain/entities'
+import { CheckLogNotFoundException } from '~/check-logs/domain/exceptions'
+import type { ICheckLogRepository } from '~/check-logs/domain/repositories'
+import type { CheckLogIdValueObject } from '~/check-logs/domain/value-objects'
+import type { PrismaProvider } from '~/shared/infrastructure/database'
+
+import { CheckLogInfrastructureMapper } from '../mappers'
+
+@Injectable()
+export class PrismaCheckLogRepository implements ICheckLogRepository {
+  constructor(private readonly prisma: PrismaProvider) {}
+
+  async create(checkLog: CheckLogEntity): Promise<CheckLogEntity> {
+    const prismaCheckLog = await this.prisma.checkLog.create({
+      data: CheckLogInfrastructureMapper.toPrisma(checkLog)
+    })
+
+    return CheckLogInfrastructureMapper.toDomain(prismaCheckLog)
+  }
+
+  async findById(id: CheckLogIdValueObject): Promise<CheckLogEntity | null> {
+    const prismaCheckLog = await this.prisma.checkLog.findUnique({
+      where: { id: id.value }
+    })
+
+    return prismaCheckLog ? CheckLogInfrastructureMapper.toDomain(prismaCheckLog) : null
+  }
+
+  async findByCheckTypeId(checkTypeId: string): Promise<CheckLogEntity[]> {
+    const prismaCheckLogs = await this.prisma.checkLog.findMany({
+      where: { checkTypeId }
+    })
+
+    return prismaCheckLogs.map(CheckLogInfrastructureMapper.toDomain)
+  }
+
+  async findByVehicleId(vehicleId: string): Promise<CheckLogEntity[]> {
+    const prismaCheckLogs = await this.prisma.checkLog.findMany({
+      where: { checkType: { vehicleId } }
+    })
+
+    return prismaCheckLogs.map(CheckLogInfrastructureMapper.toDomain)
+  }
+
+  async findMostRecentByCheckTypeIds(checkTypeIds: string[]): Promise<Map<string, CheckLogEntity>> {
+    const prismaCheckLogs = await this.prisma.checkLog.findMany({
+      where: { checkTypeId: { in: checkTypeIds } },
+      orderBy: { completedAt: 'desc' }
+    })
+
+    const map = new Map<string, CheckLogEntity>()
+
+    for (const log of prismaCheckLogs) {
+      if (!map.has(log.checkTypeId)) {
+        map.set(log.checkTypeId, CheckLogInfrastructureMapper.toDomain(log))
+      }
+    }
+
+    return map
+  }
+
+  async delete(id: CheckLogIdValueObject): Promise<void> {
+    try {
+      await this.prisma.checkLog.delete({
+        where: { id: id.value }
+      })
+    } catch (error) {
+      if (error instanceof Prisma.PrismaClientKnownRequestError) {
+        if (error.code === 'P2025') {
+          throw new CheckLogNotFoundException(id.value)
+        }
+      }
+
+      throw error
+    }
+  }
+}

--- a/apps/api/src/check-logs/infrastructure/repositories/index.ts
+++ b/apps/api/src/check-logs/infrastructure/repositories/index.ts
@@ -1,0 +1,1 @@
+export { PrismaCheckLogRepository } from './PrismaCheckLog.repository'

--- a/apps/web/src/features/check-logs/api/checkLog.service.spec.ts
+++ b/apps/web/src/features/check-logs/api/checkLog.service.spec.ts
@@ -1,0 +1,130 @@
+import type { Mock } from 'bun:test'
+import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test'
+
+import { api } from '~/lib/apiRequest'
+
+import type { CheckLog, CheckStatusSummary } from '../types'
+
+import {
+  createCheckLog,
+  deleteCheckLog,
+  getCheckLogs,
+  getCheckStatusSummary
+} from './checkLog.service'
+
+const mockCheckLog: CheckLog = {
+  id: 'cl1',
+  checkTypeId: 'ct1',
+  checkTypeName: 'Vidange',
+  completedAt: '2026-03-15',
+  notes: 'All good',
+  nextDueAt: '2026-03-22',
+  createdAt: '2026-03-15T10:00:00Z'
+}
+
+describe('checkLog.service', () => {
+  let getSpy: Mock<typeof api.get>
+  let postSpy: Mock<typeof api.post>
+  let deleteSpy: Mock<typeof api.delete>
+
+  beforeEach(() => {
+    getSpy = spyOn(api, 'get')
+    postSpy = spyOn(api, 'post')
+    deleteSpy = spyOn(api, 'delete')
+  })
+
+  afterEach(() => {
+    getSpy.mockRestore()
+    postSpy.mockRestore()
+    deleteSpy.mockRestore()
+  })
+
+  describe('getCheckLogs', () => {
+    it('should return check logs for a vehicle', async () => {
+      getSpy.mockResolvedValueOnce({ success: true, data: [mockCheckLog] })
+
+      const result = await getCheckLogs('v1')
+
+      expect(getSpy).toHaveBeenCalledWith('/vehicles/v1/check-logs')
+      expect(result).toEqual([mockCheckLog])
+    })
+
+    it('should return empty array when no logs exist', async () => {
+      getSpy.mockResolvedValueOnce({ success: true, data: [] })
+
+      const result = await getCheckLogs('v1')
+
+      expect(result).toEqual([])
+    })
+
+    it('should throw on API failure', async () => {
+      getSpy.mockResolvedValueOnce({ success: false, message: 'API error' })
+
+      await expect(getCheckLogs('v1')).rejects.toThrow('API error')
+    })
+  })
+
+  describe('createCheckLog', () => {
+    it('should call api.post with correct endpoint and data', async () => {
+      const data = { checkTypeId: 'ct1', completedAt: '2026-03-15', notes: 'OK' }
+
+      postSpy.mockResolvedValueOnce({ success: true, data: mockCheckLog })
+
+      const result = await createCheckLog('v1', data)
+
+      expect(postSpy).toHaveBeenCalledWith('/vehicles/v1/check-logs', data)
+      expect(result).toEqual(mockCheckLog)
+    })
+
+    it('should throw on failed creation', async () => {
+      const data = { checkTypeId: 'ct1', completedAt: '2026-03-15' }
+
+      postSpy.mockResolvedValueOnce({ success: false, message: 'Creation failed' })
+
+      await expect(createCheckLog('v1', data)).rejects.toThrow('Creation failed')
+    })
+  })
+
+  describe('deleteCheckLog', () => {
+    it('should call api.delete with correct endpoint', async () => {
+      deleteSpy.mockResolvedValueOnce({ success: true })
+
+      await expect(deleteCheckLog('v1', 'cl1')).resolves.toBeUndefined()
+      expect(deleteSpy).toHaveBeenCalledWith('/vehicles/v1/check-logs/cl1')
+    })
+
+    it('should throw on failed deletion', async () => {
+      deleteSpy.mockResolvedValueOnce({ success: false, message: 'Deletion failed' })
+
+      await expect(deleteCheckLog('v1', 'cl1')).rejects.toThrow('Deletion failed')
+    })
+  })
+
+  describe('getCheckStatusSummary', () => {
+    it('should return status summaries for a vehicle', async () => {
+      const summaries: CheckStatusSummary[] = [
+        {
+          checkTypeId: 'ct1',
+          checkTypeName: 'Vidange',
+          intervalDays: 7,
+          lastCompletedAt: '2026-03-15',
+          nextDueAt: '2026-03-22',
+          status: 'on-time'
+        }
+      ]
+
+      getSpy.mockResolvedValueOnce({ success: true, data: summaries })
+
+      const result = await getCheckStatusSummary('v1')
+
+      expect(getSpy).toHaveBeenCalledWith('/vehicles/v1/check-status')
+      expect(result).toEqual(summaries)
+    })
+
+    it('should throw on API failure', async () => {
+      getSpy.mockResolvedValueOnce({ success: false, message: 'API error' })
+
+      await expect(getCheckStatusSummary('v1')).rejects.toThrow('API error')
+    })
+  })
+})

--- a/apps/web/src/features/check-logs/api/checkLog.service.ts
+++ b/apps/web/src/features/check-logs/api/checkLog.service.ts
@@ -1,0 +1,39 @@
+import { api, handleApiResponse } from '~/lib'
+
+import type { CreateCheckLogSchema } from '../schemas'
+import type { CheckLog, CheckStatusSummary } from '../types'
+
+const getBaseUrl = (vehicleId: string) => `/vehicles/${vehicleId}/check-logs`
+
+export const getCheckLogs = async (vehicleId: string): Promise<CheckLog[]> => {
+  const url = getBaseUrl(vehicleId)
+  const response = await api.get<CheckLog[]>(url)
+
+  return handleApiResponse(response)
+}
+
+export const createCheckLog = async (
+  vehicleId: string,
+  data: CreateCheckLogSchema & { checkTypeId: string }
+): Promise<CheckLog> => {
+  const url = getBaseUrl(vehicleId)
+  const response = await api.post<CheckLog>(url, data)
+
+  return handleApiResponse(response)
+}
+
+export const deleteCheckLog = async (vehicleId: string, id: string): Promise<void> => {
+  const url = `${getBaseUrl(vehicleId)}/${id}`
+  const response = await api.delete<void>(url)
+
+  if (!response.success) {
+    throw new Error(response.message || 'API request failed')
+  }
+}
+
+export const getCheckStatusSummary = async (vehicleId: string): Promise<CheckStatusSummary[]> => {
+  const url = `/vehicles/${vehicleId}/check-status`
+  const response = await api.get<CheckStatusSummary[]>(url)
+
+  return handleApiResponse(response)
+}

--- a/apps/web/src/features/check-logs/api/index.ts
+++ b/apps/web/src/features/check-logs/api/index.ts
@@ -1,0 +1,6 @@
+export {
+  createCheckLog,
+  deleteCheckLog,
+  getCheckLogs,
+  getCheckStatusSummary
+} from './checkLog.service'

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -27,28 +27,28 @@
 
 #### Phase 3: Application DTOs & Mapper
 
-- [ ] CreateCheckLog DTO + tests
-- [ ] GetCheckLog DTO + tests
-- [ ] CheckStatusSummary DTO + tests
-- [ ] Application mapper + tests
+- [x] CreateCheckLog DTO + tests
+- [x] GetCheckLog DTO + tests
+- [x] CheckStatusSummary DTO + tests
+- [x] Application mapper + tests
 
 #### Phase 4: Application Use Cases & Service
 
-- [ ] CreateCheckLog use case + tests
-- [ ] ListCheckLogsByVehicle use case + tests
-- [ ] GetCheckLog use case + tests
-- [ ] DeleteCheckLog use case + tests
-- [ ] GetCheckStatusSummary use case + tests
-- [ ] CheckLog service + tests
+- [x] CreateCheckLog use case + tests
+- [x] ListCheckLogsByVehicle use case + tests
+- [x] GetCheckLog use case + tests
+- [x] DeleteCheckLog use case + tests
+- [x] GetCheckStatusSummary use case + tests
+- [x] CheckLog service + tests
 
 #### Phase 5: Infrastructure + Frontend API
 
-- [ ] Infrastructure mapper + tests
-- [ ] Prisma repository + tests
-- [ ] Frontend API service + tests
-- [ ] CheckLog controller + tests
-- [ ] CheckStatus controller + tests (separate route prefix)
-- [ ] CheckLogs module + app.module registration
+- [x] Infrastructure mapper + tests
+- [x] Prisma repository + tests
+- [x] Frontend API service + tests
+- [x] CheckLog controller + tests
+- [x] CheckStatus controller + tests (separate route prefix)
+- [x] CheckLogs module + app.module registration
 
 ---
 


### PR DESCRIPTION
## Summary

- Application DTOs (CreateCheckLog, GetCheckLog, CheckStatusSummary) with class-validator
- Application mapper with status computation logic (never/overdue/due-soon/on-time, 2-day threshold)
- 5 use cases: CreateCheckLog (date arithmetic), ListCheckLogsByVehicle, GetCheckLog, DeleteCheckLog, GetCheckStatusSummary (orchestration)
- CheckLog service facade delegating 1:1 to use cases
- Infrastructure: Prisma repository with relation filter and findMostRecentByCheckTypeIds grouping
- Controllers: CheckLog CRUD + CheckStatus GET (separate route prefixes)
- CheckLogs NestJS module with CheckTypeService cross-module injection
- Frontend API service for all check-log endpoints

## Block 2 of 4 — Feature 04: Check Logging

Covers Phases 3-5 (Application + Infrastructure + API). Next: Block 3 (frontend state + components).

## Test plan

- [x] All existing tests still pass
- [x] 9 new DTO tests (creation, serialization, null handling)
- [x] 12 new mapper tests (DTO mapping, status boundaries 0/2/3 days)
- [x] 18 new use case tests (CRUD, date arithmetic, error propagation)
- [x] 5 new service tests (delegation verification)
- [x] 4 new infra mapper tests (toDomain, toPrisma)
- [x] 9 new repository tests (CRUD, relation filter, grouping, P2025)
- [x] 6 new controller tests (CRUD, ownership, status endpoint)
- [x] 10 new frontend API tests (all endpoints, success/failure)
- [x] Typecheck, lint, format all pass