### PR TITLE
feat(check-logging): add frontend state and UI components (Block 3)

### DIFF
--- a/apps/web/src/features/check-logs/components/CheckLogCard.spec.tsx
+++ b/apps/web/src/features/check-logs/components/CheckLogCard.spec.tsx
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, mock } from 'bun:test'
+
+import { cleanup, fireEvent, render, screen } from '~/test-utils'
+
+import type { CheckLog } from '../types'
+
+import { CheckLogCard } from './CheckLogCard'
+
+const mockCheckLog: CheckLog = {
+  id: 'cl-1',
+  checkTypeId: 'ct-1',
+  checkTypeName: 'Vidange',
+  completedAt: '2026-03-15',
+  notes: 'Tout est OK',
+  nextDueAt: '2026-03-22',
+  createdAt: '2026-03-15T10:00:00Z'
+}
+
+const mockCheckLogNoNotes: CheckLog = {
+  ...mockCheckLog,
+  id: 'cl-2',
+  notes: null
+}
+
+describe('CheckLogCard', () => {
+  beforeEach(() => {
+    cleanup()
+    document.body.innerHTML = ''
+  })
+
+  it('should render the check type name', () => {
+    render(<CheckLogCard checkLog={mockCheckLog} onDelete={() => {}} />)
+
+    expect(screen.getByText('Vidange')).toBeInTheDocument()
+  })
+
+  it('should render the completed date', () => {
+    render(<CheckLogCard checkLog={mockCheckLog} onDelete={() => {}} />)
+
+    expect(screen.getByText(/Effectué le 2026-03-15/)).toBeInTheDocument()
+  })
+
+  it('should render the next due date', () => {
+    render(<CheckLogCard checkLog={mockCheckLog} onDelete={() => {}} />)
+
+    expect(screen.getByText(/Prochain le 2026-03-22/)).toBeInTheDocument()
+  })
+
+  it('should render notes when present', () => {
+    render(<CheckLogCard checkLog={mockCheckLog} onDelete={() => {}} />)
+
+    expect(screen.getByText('Tout est OK')).toBeInTheDocument()
+  })
+
+  it('should not render notes when null', () => {
+    render(<CheckLogCard checkLog={mockCheckLogNoNotes} onDelete={() => {}} />)
+
+    expect(screen.queryByText('Tout est OK')).toBeNull()
+  })
+
+  it('should render delete button', () => {
+    render(<CheckLogCard checkLog={mockCheckLog} onDelete={() => {}} />)
+
+    expect(screen.getByRole('button', { name: /supprimer/i })).toBeInTheDocument()
+  })
+
+  it('should call onDelete with check log when delete button clicked', () => {
+    const onDelete = mock(() => {})
+    render(<CheckLogCard checkLog={mockCheckLog} onDelete={onDelete} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /supprimer/i }))
+
+    expect(onDelete).toHaveBeenCalledWith(mockCheckLog)
+  })
+})

--- a/apps/web/src/features/check-logs/components/CheckLogCard.tsx
+++ b/apps/web/src/features/check-logs/components/CheckLogCard.tsx
@@ -1,0 +1,46 @@
+import { Calendar, FileText, Trash2 } from 'lucide-react'
+
+import { Button } from '~/components/ui'
+
+import type { CheckLog } from '../types'
+
+export interface CheckLogCardProps {
+  checkLog: CheckLog
+  onDelete: (checkLog: CheckLog) => void
+}
+
+export const CheckLogCard = ({ checkLog, onDelete }: CheckLogCardProps) => (
+  <article className='card card-border card-sm bg-base-200 transition-all duration-200 hover:-translate-y-0.5 hover:shadow-lg'>
+    <section className='card-body gap-3'>
+      <header className='flex flex-wrap items-start gap-2'>
+        <h2 className='card-title gap-2'>
+          <FileText size={18} className='text-primary/70 shrink-0' />
+          {checkLog.checkTypeName}
+        </h2>
+      </header>
+      <div className='text-base-content/70 flex flex-col gap-1 text-sm'>
+        <p className='flex items-center gap-2'>
+          <Calendar size={14} className='shrink-0' />
+          Effectué le {checkLog.completedAt}
+        </p>
+        <p className='flex items-center gap-2'>
+          <Calendar size={14} className='shrink-0' />
+          Prochain le {checkLog.nextDueAt}
+        </p>
+      </div>
+      {checkLog.notes && (
+        <p className='text-base-content/60 line-clamp-2 text-sm'>{checkLog.notes}</p>
+      )}
+      <footer className='card-actions justify-end'>
+        <Button
+          variant='destructive'
+          className='btn-sm btn-outline gap-1'
+          onClick={() => onDelete(checkLog)}
+        >
+          <Trash2 size={14} />
+          Supprimer
+        </Button>
+      </footer>
+    </section>
+  </article>
+)

--- a/apps/web/src/features/check-logs/components/CheckLogContainer.spec.tsx
+++ b/apps/web/src/features/check-logs/components/CheckLogContainer.spec.tsx
@@ -1,0 +1,246 @@
+import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from 'bun:test'
+
+import { $checkTypes, checkTypeActions } from '~/features/check-types/store'
+import type { CheckType } from '~/features/check-types/types'
+import type { Vehicle } from '~/features/vehicles'
+import {
+  $isLoading as $isVehicleLoading,
+  $vehicle,
+  vehicleActions
+} from '~/features/vehicles/store'
+import { cleanup, fireEvent, render, screen, waitFor } from '~/test-utils'
+
+import { $checkLogs, $error, $isLoading, checkLogActions } from '../store'
+import type { CheckLog } from '../types'
+
+import { CheckLogContainer } from './CheckLogContainer'
+
+mock.module('~/utils/navigation', () => ({
+  redirect: mock(() => {})
+}))
+
+const mockVehicle: Vehicle = {
+  id: 'v-1',
+  userId: 'u-1',
+  make: 'Mini',
+  model: 'Cooper',
+  year: 2020,
+  engineType: '1.6L Turbo',
+  fuelType: 'GASOLINE',
+  vin: null,
+  licensePlate: 'AB-123-CD',
+  purchaseDate: null,
+  mileage: 45000,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z'
+}
+
+const mockCheckTypes: CheckType[] = [
+  {
+    id: 'ct-1',
+    vehicleId: 'v-1',
+    name: 'Vidange',
+    description: null,
+    intervalDays: 7,
+    createdAt: '2026-01-01',
+    updatedAt: '2026-01-01'
+  },
+  {
+    id: 'ct-2',
+    vehicleId: 'v-1',
+    name: 'Pneus',
+    description: null,
+    intervalDays: 30,
+    createdAt: '2026-01-01',
+    updatedAt: '2026-01-01'
+  }
+]
+
+const mockCheckLogs: CheckLog[] = [
+  {
+    id: 'cl-1',
+    checkTypeId: 'ct-1',
+    checkTypeName: 'Vidange',
+    completedAt: '2026-03-15',
+    notes: 'All good',
+    nextDueAt: '2026-03-22',
+    createdAt: '2026-03-15T10:00:00Z'
+  },
+  {
+    id: 'cl-2',
+    checkTypeId: 'ct-2',
+    checkTypeName: 'Pneus',
+    completedAt: '2026-03-10',
+    notes: null,
+    nextDueAt: '2026-04-09',
+    createdAt: '2026-03-10T10:00:00Z'
+  }
+]
+
+describe('CheckLogContainer', () => {
+  let fetchVehicleSpy: ReturnType<typeof spyOn>
+  let fetchLogsSpy: ReturnType<typeof spyOn>
+  let fetchCheckTypesSpy: ReturnType<typeof spyOn>
+  let removeSpy: ReturnType<typeof spyOn>
+
+  beforeEach(() => {
+    cleanup()
+    document.body.innerHTML = ''
+
+    $vehicle.set(null)
+    $isVehicleLoading.set(false)
+    $checkLogs.set([])
+    $checkTypes.set([])
+    $isLoading.set(false)
+    $error.set(null)
+
+    fetchVehicleSpy = spyOn(vehicleActions, 'fetchVehicle').mockResolvedValue(undefined)
+    fetchLogsSpy = spyOn(checkLogActions, 'fetchLogs').mockResolvedValue(undefined)
+    fetchCheckTypesSpy = spyOn(checkTypeActions, 'fetchByVehicle').mockResolvedValue(undefined)
+    removeSpy = spyOn(checkLogActions, 'remove').mockResolvedValue(undefined)
+  })
+
+  afterEach(() => {
+    fetchVehicleSpy.mockRestore()
+    fetchLogsSpy.mockRestore()
+    fetchCheckTypesSpy.mockRestore()
+    removeSpy.mockRestore()
+  })
+
+  it('should show loading state initially', () => {
+    $isVehicleLoading.set(true)
+
+    render(<CheckLogContainer />)
+
+    expect(screen.getByText('Chargement...')).toBeInTheDocument()
+  })
+
+  it('should render the list with title and filter after loading', async () => {
+    $vehicle.set(mockVehicle)
+    $checkLogs.set(mockCheckLogs)
+    $checkTypes.set(mockCheckTypes)
+
+    render(<CheckLogContainer />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Historique des contrôles')).toBeInTheDocument()
+      expect(screen.getByText('Filtrer par type')).toBeInTheDocument()
+      expect(screen.getByText('All good')).toBeInTheDocument()
+      expect(screen.getByText(/Effectué le 2026-03-15/)).toBeInTheDocument()
+      expect(screen.getByText(/Effectué le 2026-03-10/)).toBeInTheDocument()
+    })
+  })
+
+  it('should filter logs by selected check type', async () => {
+    $vehicle.set(mockVehicle)
+    $checkLogs.set(mockCheckLogs)
+    $checkTypes.set(mockCheckTypes)
+
+    render(<CheckLogContainer />)
+
+    await waitFor(() => {
+      expect(screen.getByText(/Effectué le 2026-03-15/)).toBeInTheDocument()
+      expect(screen.getByText(/Effectué le 2026-03-10/)).toBeInTheDocument()
+    })
+
+    fireEvent.change(screen.getByLabelText('Filtrer par type'), { target: { value: 'ct-1' } })
+
+    await waitFor(() => {
+      expect(screen.getByText(/Effectué le 2026-03-15/)).toBeInTheDocument()
+      expect(screen.queryByText(/Effectué le 2026-03-10/)).not.toBeInTheDocument()
+    })
+  })
+
+  it('should show all logs when "Tous les types" is selected', async () => {
+    $vehicle.set(mockVehicle)
+    $checkLogs.set(mockCheckLogs)
+    $checkTypes.set(mockCheckTypes)
+
+    render(<CheckLogContainer />)
+
+    await waitFor(() => {
+      expect(screen.getByText(/Effectué le 2026-03-15/)).toBeInTheDocument()
+      expect(screen.getByText(/Effectué le 2026-03-10/)).toBeInTheDocument()
+    })
+
+    fireEvent.change(screen.getByLabelText('Filtrer par type'), { target: { value: 'ct-1' } })
+
+    await waitFor(() => {
+      expect(screen.queryByText(/Effectué le 2026-03-10/)).not.toBeInTheDocument()
+    })
+
+    fireEvent.change(screen.getByLabelText('Filtrer par type'), { target: { value: '' } })
+
+    await waitFor(() => {
+      expect(screen.getByText(/Effectué le 2026-03-15/)).toBeInTheDocument()
+      expect(screen.getByText(/Effectué le 2026-03-10/)).toBeInTheDocument()
+    })
+  })
+
+  it('should show delete dialog when delete is clicked', async () => {
+    $vehicle.set(mockVehicle)
+    $checkLogs.set(mockCheckLogs)
+    $checkTypes.set(mockCheckTypes)
+
+    render(<CheckLogContainer />)
+
+    await waitFor(() => {
+      expect(screen.getByText('All good')).toBeInTheDocument()
+    })
+
+    const deleteButtons = screen.getAllByRole('button', { name: /supprimer/i })
+    fireEvent.click(deleteButtons[0])
+
+    await waitFor(() => {
+      expect(screen.getByText('Supprimer le contrôle')).toBeInTheDocument()
+      expect(screen.getByText(/Êtes-vous sûr de vouloir supprimer ce contrôle/)).toBeInTheDocument()
+    })
+  })
+
+  it('should call remove and close dialog on delete confirm', async () => {
+    $vehicle.set(mockVehicle)
+    $checkLogs.set(mockCheckLogs)
+    $checkTypes.set(mockCheckTypes)
+
+    render(<CheckLogContainer />)
+
+    await waitFor(() => {
+      expect(screen.getByText('All good')).toBeInTheDocument()
+    })
+
+    const deleteButtons = screen.getAllByRole('button', { name: /supprimer/i })
+    fireEvent.click(deleteButtons[0])
+
+    await waitFor(() => {
+      expect(screen.getByText('Supprimer le contrôle')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Supprimer' }))
+
+    await waitFor(() => {
+      expect(removeSpy).toHaveBeenCalledWith(mockVehicle.id, 'cl-1')
+    })
+  })
+
+  it('should show empty state when no logs exist', async () => {
+    $vehicle.set(mockVehicle)
+    $checkLogs.set([])
+
+    render(<CheckLogContainer />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Aucun contrôle enregistré')).toBeInTheDocument()
+    })
+  })
+
+  it('should display error when error exists', async () => {
+    $vehicle.set(mockVehicle)
+    $error.set('Test error')
+
+    render(<CheckLogContainer />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Test error')).toBeInTheDocument()
+    })
+  })
+})

--- a/apps/web/src/features/check-logs/components/CheckLogContainer.tsx
+++ b/apps/web/src/features/check-logs/components/CheckLogContainer.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 
 import { useCheckTypes } from '~/features/check-types'
 import { useVehicle } from '~/features/vehicles'
+import { redirect } from '~/utils/navigation'
 
 import { useCheckLogs } from '../hooks'
 import type { CheckLog } from '../types'
@@ -12,6 +13,7 @@ import { DeleteCheckLogDialog } from './DeleteCheckLogDialog'
 
 export const CheckLogContainer = () => {
   const [mode, setMode] = useState<'loading' | 'list'>('loading')
+  const [hasFetchedVehicle, setHasFetchedVehicle] = useState(false)
   const [selectedCheckTypeId, setSelectedCheckTypeId] = useState<string | null>(null)
   const [deletingCheckLog, setDeletingCheckLog] = useState<CheckLog | null>(null)
   const { vehicle, fetchVehicle, hasVehicle } = useVehicle()
@@ -19,7 +21,11 @@ export const CheckLogContainer = () => {
   const { checkTypes, fetchByVehicle } = useCheckTypes()
 
   useEffect(() => {
-    fetchVehicle()
+    const load = async () => {
+      await fetchVehicle()
+      setHasFetchedVehicle(true)
+    }
+    load()
   }, [fetchVehicle])
 
   useEffect(() => {
@@ -31,9 +37,15 @@ export const CheckLogContainer = () => {
 
   useEffect(() => {
     if (mode !== 'loading') return
-    if (!hasVehicle) return
+    if (!hasFetchedVehicle && !hasVehicle) return
+
+    if (!hasVehicle) {
+      redirect('/vehicle')
+      return
+    }
+
     if (vehicle && !isLoading) setMode('list')
-  }, [mode, hasVehicle, vehicle, isLoading])
+  }, [mode, hasFetchedVehicle, hasVehicle, vehicle, isLoading])
 
   const filteredLogs = selectedCheckTypeId
     ? logs.filter(log => log.checkTypeId === selectedCheckTypeId)

--- a/apps/web/src/features/check-logs/components/CheckLogContainer.tsx
+++ b/apps/web/src/features/check-logs/components/CheckLogContainer.tsx
@@ -1,0 +1,76 @@
+import { useEffect, useState } from 'react'
+
+import { useCheckTypes } from '~/features/check-types'
+import { useVehicle } from '~/features/vehicles'
+
+import { useCheckLogs } from '../hooks'
+import type { CheckLog } from '../types'
+
+import { CheckLogList } from './CheckLogList'
+import { CheckTypeFilter } from './CheckTypeFilter'
+import { DeleteCheckLogDialog } from './DeleteCheckLogDialog'
+
+export const CheckLogContainer = () => {
+  const [mode, setMode] = useState<'loading' | 'list'>('loading')
+  const [selectedCheckTypeId, setSelectedCheckTypeId] = useState<string | null>(null)
+  const [deletingCheckLog, setDeletingCheckLog] = useState<CheckLog | null>(null)
+  const { vehicle, fetchVehicle, hasVehicle } = useVehicle()
+  const { logs, error, isLoading, fetchLogs, remove } = useCheckLogs()
+  const { checkTypes, fetchByVehicle } = useCheckTypes()
+
+  useEffect(() => {
+    fetchVehicle()
+  }, [fetchVehicle])
+
+  useEffect(() => {
+    if (hasVehicle && vehicle) {
+      fetchLogs(vehicle.id)
+      fetchByVehicle(vehicle.id)
+    }
+  }, [hasVehicle, vehicle, fetchLogs, fetchByVehicle])
+
+  useEffect(() => {
+    if (mode !== 'loading') return
+    if (!hasVehicle) return
+    if (vehicle && !isLoading) setMode('list')
+  }, [mode, hasVehicle, vehicle, isLoading])
+
+  const filteredLogs = selectedCheckTypeId
+    ? logs.filter(log => log.checkTypeId === selectedCheckTypeId)
+    : logs
+
+  const handleDeleteConfirm = async () => {
+    if (!vehicle || !deletingCheckLog) return
+
+    try {
+      await remove(vehicle.id, deletingCheckLog.id)
+      setDeletingCheckLog(null)
+    } catch (error) {
+      setDeletingCheckLog(null)
+    }
+  }
+
+  if (mode === 'loading') {
+    return <p>Chargement...</p>
+  }
+
+  return (
+    <section>
+      <h1>Historique des contrôles</h1>
+      {error && <p className='alert alert-error'>{error}</p>}
+      <CheckTypeFilter
+        checkTypes={checkTypes}
+        selectedCheckTypeId={selectedCheckTypeId}
+        onChange={setSelectedCheckTypeId}
+      />
+      <CheckLogList checkLogs={filteredLogs} onDelete={setDeletingCheckLog} />
+      {deletingCheckLog && (
+        <DeleteCheckLogDialog
+          checkTypeName={deletingCheckLog.checkTypeName}
+          onConfirm={handleDeleteConfirm}
+          onCancel={() => setDeletingCheckLog(null)}
+        />
+      )}
+    </section>
+  )
+}

--- a/apps/web/src/features/check-logs/components/CheckLogList.spec.tsx
+++ b/apps/web/src/features/check-logs/components/CheckLogList.spec.tsx
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it } from 'bun:test'
+
+import { cleanup, render, screen } from '~/test-utils'
+
+import type { CheckLog } from '../types'
+
+import { CheckLogList } from './CheckLogList'
+
+const mockCheckLog1: CheckLog = {
+  id: 'cl-1',
+  checkTypeId: 'ct-1',
+  checkTypeName: 'Vidange',
+  completedAt: '2026-03-15',
+  notes: 'All good',
+  nextDueAt: '2026-03-22',
+  createdAt: '2026-03-15T10:00:00Z'
+}
+
+const mockCheckLog2: CheckLog = {
+  id: 'cl-2',
+  checkTypeId: 'ct-1',
+  checkTypeName: 'Vidange',
+  completedAt: '2026-03-10',
+  notes: null,
+  nextDueAt: '2026-03-17',
+  createdAt: '2026-03-10T10:00:00Z'
+}
+
+describe('CheckLogList', () => {
+  beforeEach(() => {
+    cleanup()
+    document.body.innerHTML = ''
+  })
+
+  it('should render a card for each check log', () => {
+    render(<CheckLogList checkLogs={[mockCheckLog1, mockCheckLog2]} onDelete={() => {}} />)
+
+    expect(screen.getAllByText('Vidange')).toHaveLength(2)
+  })
+
+  it('should render empty state when no logs', () => {
+    render(<CheckLogList checkLogs={[]} onDelete={() => {}} />)
+
+    expect(screen.getByText('Aucun contrôle enregistré')).toBeInTheDocument()
+  })
+
+  it('should not render empty state when logs exist', () => {
+    render(<CheckLogList checkLogs={[mockCheckLog1]} onDelete={() => {}} />)
+
+    expect(screen.queryByText('Aucun contrôle enregistré')).toBeNull()
+  })
+
+  it('should use grid layout', () => {
+    const { container } = render(<CheckLogList checkLogs={[mockCheckLog1]} onDelete={() => {}} />)
+
+    const grid = container.querySelector('.grid')
+
+    expect(grid).toBeInTheDocument()
+  })
+})

--- a/apps/web/src/features/check-logs/components/CheckLogList.tsx
+++ b/apps/web/src/features/check-logs/components/CheckLogList.tsx
@@ -1,0 +1,29 @@
+import { ClipboardList } from 'lucide-react'
+
+import type { CheckLog } from '../types'
+
+import { CheckLogCard } from './CheckLogCard'
+
+export interface CheckLogListProps {
+  checkLogs: CheckLog[]
+  onDelete: (checkLog: CheckLog) => void
+}
+
+export const CheckLogList = ({ checkLogs, onDelete }: CheckLogListProps) => {
+  if (checkLogs.length === 0) {
+    return (
+      <section className='flex flex-col items-center justify-center gap-4 py-12'>
+        <ClipboardList size={48} className='text-base-content/30' />
+        <p className='text-base-content/50 text-lg'>Aucun contrôle enregistré</p>
+      </section>
+    )
+  }
+
+  return (
+    <section className='grid grid-cols-1 gap-5 md:grid-cols-2 lg:grid-cols-3'>
+      {checkLogs.map(checkLog => (
+        <CheckLogCard key={checkLog.id} checkLog={checkLog} onDelete={onDelete} />
+      ))}
+    </section>
+  )
+}

--- a/apps/web/src/features/check-logs/components/CheckStatusBadge.spec.tsx
+++ b/apps/web/src/features/check-logs/components/CheckStatusBadge.spec.tsx
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, it } from 'bun:test'
+
+import { cleanup, render, screen } from '~/test-utils'
+
+import { CheckStatusBadge } from './CheckStatusBadge'
+
+describe('CheckStatusBadge', () => {
+  beforeEach(() => {
+    cleanup()
+    document.body.innerHTML = ''
+  })
+
+  it('should render "À jour" with badge-success for on-time status', () => {
+    render(<CheckStatusBadge status='on-time' />)
+
+    const badge = screen.getByText('À jour')
+
+    expect(badge).toBeInTheDocument()
+    expect(badge).toHaveClass('badge-success')
+  })
+
+  it('should render "Bientôt" with badge-warning for due-soon status', () => {
+    render(<CheckStatusBadge status='due-soon' />)
+
+    const badge = screen.getByText('Bientôt')
+
+    expect(badge).toBeInTheDocument()
+    expect(badge).toHaveClass('badge-warning')
+  })
+
+  it('should render "En retard" with badge-error for overdue status', () => {
+    render(<CheckStatusBadge status='overdue' />)
+
+    const badge = screen.getByText('En retard')
+
+    expect(badge).toBeInTheDocument()
+    expect(badge).toHaveClass('badge-error')
+  })
+
+  it('should render "Jamais effectué" with badge-neutral for never status', () => {
+    render(<CheckStatusBadge status='never' />)
+
+    const badge = screen.getByText('Jamais effectué')
+
+    expect(badge).toBeInTheDocument()
+    expect(badge).toHaveClass('badge-neutral')
+  })
+})

--- a/apps/web/src/features/check-logs/components/CheckStatusBadge.tsx
+++ b/apps/web/src/features/check-logs/components/CheckStatusBadge.tsx
@@ -1,0 +1,23 @@
+import type { CheckStatus } from '../types'
+
+export interface CheckStatusBadgeProps {
+  status: CheckStatus
+}
+
+type StatusConfig = {
+  className: string
+  label: string
+}
+
+export const CheckStatusBadge = ({ status }: CheckStatusBadgeProps) => {
+  const statusConfig: Record<CheckStatus, StatusConfig> = {
+    'on-time': { className: 'badge-success', label: 'À jour' },
+    'due-soon': { className: 'badge-warning', label: 'Bientôt' },
+    overdue: { className: 'badge-error', label: 'En retard' },
+    never: { className: 'badge-neutral', label: 'Jamais effectué' }
+  }
+
+  return (
+    <span className={`badge ${statusConfig[status].className}`}>{statusConfig[status].label}</span>
+  )
+}

--- a/apps/web/src/features/check-logs/components/CheckTypeFilter.spec.tsx
+++ b/apps/web/src/features/check-logs/components/CheckTypeFilter.spec.tsx
@@ -1,0 +1,121 @@
+import { beforeEach, describe, expect, it, mock } from 'bun:test'
+
+import type { CheckType } from '~/features/check-types/types'
+import { cleanup, fireEvent, render } from '~/test-utils'
+
+import { CheckTypeFilter } from './CheckTypeFilter'
+
+const mockCheckTypes: CheckType[] = [
+  {
+    id: 'ct-1',
+    vehicleId: 'v-1',
+    name: 'Vidange',
+    description: null,
+    intervalDays: 7,
+    createdAt: '2026-01-01',
+    updatedAt: '2026-01-01'
+  },
+  {
+    id: 'ct-2',
+    vehicleId: 'v-1',
+    name: 'Pneus',
+    description: null,
+    intervalDays: 30,
+    createdAt: '2026-01-01',
+    updatedAt: '2026-01-01'
+  }
+]
+
+describe('CheckTypeFilter', () => {
+  beforeEach(() => {
+    cleanup()
+    document.body.innerHTML = ''
+  })
+
+  it('should render a select with "Tous les types" and check type options', () => {
+    const { getByLabelText } = render(
+      <CheckTypeFilter checkTypes={mockCheckTypes} selectedCheckTypeId={null} onChange={() => {}} />
+    )
+
+    const select = getByLabelText('Filtrer par type') as HTMLSelectElement
+
+    expect(select).toBeInTheDocument()
+    expect(select.options.length).toBe(3)
+    expect(select.options[0].value).toBe('')
+    expect(select.options[0].text).toBe('Tous les types')
+    expect(select.options[1].value).toBe('ct-1')
+    expect(select.options[1].text).toBe('Vidange')
+    expect(select.options[2].value).toBe('ct-2')
+    expect(select.options[2].text).toBe('Pneus')
+  })
+
+  it('should render with the label "Filtrer par type"', () => {
+    const { getByLabelText } = render(
+      <CheckTypeFilter checkTypes={mockCheckTypes} selectedCheckTypeId={null} onChange={() => {}} />
+    )
+
+    const select = getByLabelText('Filtrer par type')
+
+    expect(select).toBeInTheDocument()
+  })
+
+  it('should select "Tous les types" when selectedCheckTypeId is null', () => {
+    const { getByLabelText } = render(
+      <CheckTypeFilter checkTypes={mockCheckTypes} selectedCheckTypeId={null} onChange={() => {}} />
+    )
+
+    const select = getByLabelText('Filtrer par type') as HTMLSelectElement
+
+    expect(select.value).toBe('')
+  })
+
+  it('should select the correct check type when selectedCheckTypeId is set', () => {
+    const { getByLabelText } = render(
+      <CheckTypeFilter
+        checkTypes={mockCheckTypes}
+        selectedCheckTypeId={'ct-1'}
+        onChange={() => {}}
+      />
+    )
+
+    const select = getByLabelText('Filtrer par type') as HTMLSelectElement
+
+    expect(select.value).toBe('ct-1')
+  })
+
+  it('should call onChange with checkTypeId when a type is selected', () => {
+    const onChangeMock = mock(() => {})
+
+    const { getByLabelText } = render(
+      <CheckTypeFilter
+        checkTypes={mockCheckTypes}
+        selectedCheckTypeId={null}
+        onChange={onChangeMock}
+      />
+    )
+
+    const select = getByLabelText('Filtrer par type') as HTMLSelectElement
+
+    fireEvent.change(select, { target: { value: 'ct-1' } })
+
+    expect(onChangeMock).toHaveBeenCalledWith('ct-1')
+  })
+
+  it('should call onChange with null when "Tous les types" is selected', () => {
+    const onChangeMock = mock(() => {})
+
+    const { getByLabelText } = render(
+      <CheckTypeFilter
+        checkTypes={mockCheckTypes}
+        selectedCheckTypeId={'ct-1'}
+        onChange={onChangeMock}
+      />
+    )
+
+    const select = getByLabelText('Filtrer par type') as HTMLSelectElement
+
+    fireEvent.change(select, { target: { value: '' } })
+
+    expect(onChangeMock).toHaveBeenCalledWith(null)
+  })
+})

--- a/apps/web/src/features/check-logs/components/CheckTypeFilter.tsx
+++ b/apps/web/src/features/check-logs/components/CheckTypeFilter.tsx
@@ -1,0 +1,28 @@
+import { Select } from '~/components/ui'
+import type { CheckType } from '~/features/check-types/types'
+
+export interface CheckTypeFilterProps {
+  checkTypes: CheckType[]
+  selectedCheckTypeId: string | null
+  onChange: (checkTypeId: string | null) => void
+}
+
+export const CheckTypeFilter = ({
+  checkTypes,
+  selectedCheckTypeId,
+  onChange
+}: CheckTypeFilterProps) => {
+  const options = [
+    { value: '', label: 'Tous les types' },
+    ...checkTypes.map(ct => ({ value: ct.id, label: ct.name }))
+  ]
+
+  return (
+    <Select
+      label='Filtrer par type'
+      options={options}
+      value={selectedCheckTypeId ?? ''}
+      onChange={e => onChange(e.target.value === '' ? null : e.target.value)}
+    />
+  )
+}

--- a/apps/web/src/features/check-logs/components/DeleteCheckLogDialog.spec.tsx
+++ b/apps/web/src/features/check-logs/components/DeleteCheckLogDialog.spec.tsx
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, mock } from 'bun:test'
+
+import { cleanup, render, screen } from '~/test-utils'
+
+import { DeleteCheckLogDialog } from './DeleteCheckLogDialog'
+
+describe('DeleteCheckLogDialog', () => {
+  beforeEach(() => {
+    cleanup()
+    document.body.innerHTML = ''
+  })
+
+  it('should render the delete title', () => {
+    render(
+      <DeleteCheckLogDialog checkTypeName='Vidange' onConfirm={() => {}} onCancel={() => {}} />
+    )
+
+    expect(screen.getByText('Supprimer le contrôle')).toBeInTheDocument()
+  })
+
+  it('should include the check type name in the warning message', () => {
+    render(
+      <DeleteCheckLogDialog checkTypeName='Vidange' onConfirm={() => {}} onCancel={() => {}} />
+    )
+
+    expect(
+      screen.getByText(
+        'Êtes-vous sûr de vouloir supprimer ce contrôle de "Vidange" ? Cette action est irréversible.'
+      )
+    ).toBeInTheDocument()
+  })
+
+  it('should render Supprimer and Annuler buttons', () => {
+    render(
+      <DeleteCheckLogDialog checkTypeName='Vidange' onConfirm={() => {}} onCancel={() => {}} />
+    )
+
+    expect(screen.getByRole('button', { name: 'Supprimer' })).toBeVisible()
+    expect(screen.getByRole('button', { name: 'Annuler' })).toBeVisible()
+  })
+
+  it('should call onConfirm when Supprimer is clicked', () => {
+    const onConfirm = mock(() => {})
+
+    render(
+      <DeleteCheckLogDialog checkTypeName='Vidange' onConfirm={onConfirm} onCancel={() => {}} />
+    )
+
+    screen.getByRole('button', { name: 'Supprimer' }).click()
+
+    expect(onConfirm).toHaveBeenCalled()
+  })
+
+  it('should call onCancel when Annuler is clicked', () => {
+    const onCancel = mock(() => {})
+
+    render(
+      <DeleteCheckLogDialog checkTypeName='Vidange' onConfirm={() => {}} onCancel={onCancel} />
+    )
+
+    screen.getByRole('button', { name: 'Annuler' }).click()
+
+    expect(onCancel).toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/features/check-logs/components/DeleteCheckLogDialog.tsx
+++ b/apps/web/src/features/check-logs/components/DeleteCheckLogDialog.tsx
@@ -1,0 +1,22 @@
+import { ConfirmDialog } from '~/components/ui'
+
+export interface DeleteCheckLogDialogProps {
+  checkTypeName: string
+  onConfirm: () => void
+  onCancel: () => void
+}
+
+export const DeleteCheckLogDialog = ({
+  checkTypeName,
+  onConfirm,
+  onCancel
+}: DeleteCheckLogDialogProps) => (
+  <ConfirmDialog
+    title='Supprimer le contrôle'
+    message={`Êtes-vous sûr de vouloir supprimer ce contrôle de "${checkTypeName}" ? Cette action est irréversible.`}
+    confirmLabel='Supprimer'
+    cancelLabel='Annuler'
+    onConfirm={onConfirm}
+    onCancel={onCancel}
+  />
+)

--- a/apps/web/src/features/check-logs/components/LogCheckDialog.spec.tsx
+++ b/apps/web/src/features/check-logs/components/LogCheckDialog.spec.tsx
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, mock } from 'bun:test'
+
+import { cleanup, fireEvent, render, screen, waitFor } from '~/test-utils'
+
+import { LogCheckDialog } from './LogCheckDialog'
+
+const renderDialog = async (props: Partial<Parameters<typeof LogCheckDialog>[0]> = {}) => {
+  const result = render(
+    <LogCheckDialog
+      checkTypeName={props.checkTypeName ?? 'Vidange'}
+      onSubmit={props.onSubmit ?? (() => {})}
+      onCancel={props.onCancel ?? (() => {})}
+    />
+  )
+
+  await waitFor(() => {
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+  })
+
+  return result
+}
+
+describe('LogCheckDialog', () => {
+  beforeEach(() => {
+    cleanup()
+    document.body.innerHTML = ''
+  })
+
+  it('should render the dialog with check type name in title', async () => {
+    await renderDialog()
+
+    expect(screen.getByText(/Enregistrer un contrôle: Vidange/i)).toBeInTheDocument()
+  })
+
+  it('should render the form with date and notes fields', async () => {
+    await renderDialog()
+
+    expect(screen.getByLabelText('Date du contrôle')).toBeInTheDocument()
+    expect(screen.getByLabelText('Notes')).toBeInTheDocument()
+  })
+
+  it('should default completedAt to today', async () => {
+    await renderDialog()
+
+    const today = new Date().toISOString().split('T')[0]
+    const dateInput = screen.getByLabelText('Date du contrôle') as HTMLInputElement
+
+    expect(dateInput.value).toBe(today)
+  })
+
+  it('should render cancel and submit buttons', async () => {
+    await renderDialog()
+
+    expect(screen.getByRole('button', { name: /Annuler/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Enregistrer/i })).toBeInTheDocument()
+  })
+
+  it('should call onCancel when cancel button is clicked', async () => {
+    const onCancel = mock(() => {})
+
+    await renderDialog({ onCancel })
+
+    fireEvent.click(screen.getByRole('button', { name: /Annuler/i }))
+    expect(onCancel).toHaveBeenCalledTimes(1)
+  })
+
+  it('should use DaisyUI modal classes', async () => {
+    await renderDialog()
+
+    const dialog = screen.getByRole('dialog')
+
+    expect(dialog).toHaveClass('modal')
+    expect(dialog).toHaveClass('modal-open')
+    expect(dialog.querySelector('.modal-box')).toBeInTheDocument()
+    expect(dialog.querySelector('.modal-action')).toBeInTheDocument()
+  })
+})

--- a/apps/web/src/features/check-logs/components/LogCheckDialog.tsx
+++ b/apps/web/src/features/check-logs/components/LogCheckDialog.tsx
@@ -1,0 +1,55 @@
+import { zodResolver } from '@hookform/resolvers/zod'
+import * as Dialog from '@radix-ui/react-dialog'
+import { useForm } from 'react-hook-form'
+
+import { Button, FormWrapper } from '~/components/ui'
+
+import type { CreateCheckLogSchema } from '../schemas'
+import { createCheckLogSchema } from '../schemas'
+
+import { LogCheckForm } from './LogCheckForm'
+
+export interface LogCheckDialogProps {
+  checkTypeName: string
+  onSubmit: (data: CreateCheckLogSchema) => void
+  onCancel: () => void
+}
+
+export const LogCheckDialog = ({ checkTypeName, onSubmit, onCancel }: LogCheckDialogProps) => {
+  const today = new Date().toISOString().split('T')[0]
+  const form = useForm<CreateCheckLogSchema>({
+    resolver: zodResolver(createCheckLogSchema),
+    defaultValues: {
+      completedAt: today,
+      notes: ''
+    }
+  })
+
+  return (
+    <Dialog.Root open={true} onOpenChange={onCancel}>
+      <Dialog.Portal>
+        <Dialog.Overlay className='bg-neutral/50 fixed inset-0' onClick={onCancel} />
+        <Dialog.Content
+          className='modal modal-open'
+          onInteractOutside={event => event.preventDefault()}
+          aria-describedby={undefined}
+        >
+          <div className='modal-box'>
+            <Dialog.Title className='mb-4 text-lg font-bold'>
+              Enregistrer un contrôle: {checkTypeName}
+            </Dialog.Title>
+            <FormWrapper onSubmit={form.handleSubmit(onSubmit)} className='grid gap-4'>
+              <LogCheckForm form={form} />
+              <div className='modal-action'>
+                <Button variant='outline' onClick={onCancel}>
+                  Annuler
+                </Button>
+                <Button type='submit'>Enregistrer</Button>
+              </div>
+            </FormWrapper>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  )
+}

--- a/apps/web/src/features/check-logs/components/LogCheckDialog.tsx
+++ b/apps/web/src/features/check-logs/components/LogCheckDialog.tsx
@@ -41,7 +41,7 @@ export const LogCheckDialog = ({ checkTypeName, onSubmit, onCancel }: LogCheckDi
             <FormWrapper onSubmit={form.handleSubmit(onSubmit)} className='grid gap-4'>
               <LogCheckForm form={form} />
               <div className='modal-action'>
-                <Button variant='outline' onClick={onCancel}>
+                <Button variant='outline' type='button' onClick={onCancel}>
                   Annuler
                 </Button>
                 <Button type='submit'>Enregistrer</Button>

--- a/apps/web/src/features/check-logs/components/LogCheckForm.spec.tsx
+++ b/apps/web/src/features/check-logs/components/LogCheckForm.spec.tsx
@@ -1,0 +1,95 @@
+import { zodResolver } from '@hookform/resolvers/zod'
+import { beforeEach, describe, expect, it } from 'bun:test'
+import { useForm } from 'react-hook-form'
+
+import { cleanup, render, screen } from '~/test-utils'
+
+import type { CreateCheckLogSchema } from '../schemas'
+import { createCheckLogSchema } from '../schemas'
+
+import { LogCheckForm } from './LogCheckForm'
+
+const TestWrapper = () => {
+  const form = useForm<CreateCheckLogSchema>({
+    resolver: zodResolver(createCheckLogSchema),
+    defaultValues: {
+      completedAt: '',
+      notes: undefined
+    }
+  })
+
+  return <LogCheckForm form={form} />
+}
+
+const TestWrapperWithValues = () => {
+  const form = useForm<CreateCheckLogSchema>({
+    resolver: zodResolver(createCheckLogSchema),
+    defaultValues: {
+      completedAt: '2026-03-15',
+      notes: 'Tout est OK'
+    }
+  })
+
+  return <LogCheckForm form={form} />
+}
+
+describe('LogCheckForm', () => {
+  beforeEach(() => {
+    cleanup()
+    document.body.innerHTML = ''
+  })
+
+  it('should render date and notes fields with French labels', () => {
+    render(<TestWrapper />)
+
+    expect(screen.getByLabelText('Date du contrôle')).toBeInTheDocument()
+    expect(screen.getByLabelText('Notes')).toBeInTheDocument()
+  })
+
+  it('should render completedAt as a date input', () => {
+    render(<TestWrapper />)
+
+    const dateInput = screen.getByLabelText('Date du contrôle')
+
+    expect(dateInput).toBeInTheDocument()
+    expect(dateInput).toHaveAttribute('type', 'date')
+  })
+
+  it('should set max attribute to today on the date input', () => {
+    render(<TestWrapper />)
+
+    const dateInput = screen.getByLabelText('Date du contrôle')
+    const today = new Date().toISOString().split('T')[0]
+
+    expect(dateInput).toHaveAttribute('max', today)
+  })
+
+  it('should render notes as a textarea element', () => {
+    render(<TestWrapper />)
+
+    const notesInput = screen.getByLabelText('Notes')
+
+    expect(notesInput).toBeInTheDocument()
+    expect(notesInput.tagName).toBe('TEXTAREA')
+  })
+
+  it('should pre-fill fields when form has defaultValues', () => {
+    render(<TestWrapperWithValues />)
+
+    const dateInput = screen.getByLabelText('Date du contrôle')
+    const notesInput = screen.getByLabelText('Notes')
+
+    expect(dateInput).toHaveValue('2026-03-15')
+    expect(notesInput).toHaveValue('Tout est OK')
+  })
+
+  it('should register form fields with correct names', () => {
+    render(<TestWrapper />)
+
+    const dateInput = screen.getByLabelText('Date du contrôle')
+    const notesInput = screen.getByLabelText('Notes')
+
+    expect(dateInput).toHaveAttribute('name', 'completedAt')
+    expect(notesInput).toHaveAttribute('name', 'notes')
+  })
+})

--- a/apps/web/src/features/check-logs/components/LogCheckForm.tsx
+++ b/apps/web/src/features/check-logs/components/LogCheckForm.tsx
@@ -1,0 +1,26 @@
+import type { UseFormReturn } from 'react-hook-form'
+
+import { Input, Textarea } from '~/components/ui'
+
+import type { CreateCheckLogSchema } from '../schemas'
+
+export interface LogCheckFormProps {
+  form: UseFormReturn<CreateCheckLogSchema>
+}
+
+export const LogCheckForm = ({ form }: LogCheckFormProps) => (
+  <>
+    <Input
+      type='date'
+      label='Date du contrôle'
+      {...form.register('completedAt')}
+      error={form.formState.errors.completedAt?.message}
+      max={new Date().toISOString().split('T')[0]}
+    />
+    <Textarea
+      label='Notes'
+      {...form.register('notes')}
+      error={form.formState.errors.notes?.message}
+    />
+  </>
+)

--- a/apps/web/src/features/check-logs/hooks/index.ts
+++ b/apps/web/src/features/check-logs/hooks/index.ts
@@ -1,0 +1,1 @@
+export { useCheckLogs, type UseCheckLogsReturn } from './useCheckLogs'

--- a/apps/web/src/features/check-logs/hooks/useCheckLogs.spec.ts
+++ b/apps/web/src/features/check-logs/hooks/useCheckLogs.spec.ts
@@ -1,0 +1,148 @@
+import { beforeEach, describe, expect, it, spyOn } from 'bun:test'
+
+import { cleanup, renderHook } from '~/test-utils'
+
+import { $checkLogs, $checkStatuses, $error, $isLoading, checkLogActions } from '../store'
+import type { CheckLog, CheckStatusSummary } from '../types'
+
+import { useCheckLogs } from './useCheckLogs'
+
+const mockCheckLog: CheckLog = {
+  id: 'cl1',
+  checkTypeId: 'ct1',
+  checkTypeName: 'Vidange',
+  completedAt: '2026-03-15',
+  notes: 'All good',
+  nextDueAt: '2026-03-22',
+  createdAt: '2026-03-15T10:00:00Z'
+}
+
+const mockStatusSummary: CheckStatusSummary = {
+  checkTypeId: 'ct1',
+  checkTypeName: 'Vidange',
+  intervalDays: 7,
+  lastCompletedAt: '2026-03-15',
+  nextDueAt: '2026-03-22',
+  status: 'on-time'
+}
+
+describe('useCheckLogs', () => {
+  beforeEach(() => {
+    cleanup()
+    document.body.innerHTML = ''
+
+    $checkLogs.set([])
+    $checkStatuses.set([])
+    $isLoading.set(false)
+    $error.set(null)
+  })
+
+  describe('reactive state', () => {
+    it('should return logs from store', () => {
+      $checkLogs.set([mockCheckLog])
+
+      const { result } = renderHook(() => useCheckLogs())
+
+      expect(result.current.logs).toEqual([mockCheckLog])
+    })
+
+    it('should return statuses from store', () => {
+      $checkStatuses.set([mockStatusSummary])
+
+      const { result } = renderHook(() => useCheckLogs())
+
+      expect(result.current.statuses).toEqual([mockStatusSummary])
+    })
+
+    it('should return isLoading from store', () => {
+      $isLoading.set(true)
+
+      const { result } = renderHook(() => useCheckLogs())
+
+      expect(result.current.isLoading).toBe(true)
+    })
+
+    it('should return error from store', () => {
+      $error.set('Error message')
+
+      const { result } = renderHook(() => useCheckLogs())
+
+      expect(result.current.error).toBe('Error message')
+    })
+
+    it('should return hasCheckLogs as true when logs exist', () => {
+      $checkLogs.set([mockCheckLog])
+
+      const { result } = renderHook(() => useCheckLogs())
+
+      expect(result.current.hasCheckLogs).toBe(true)
+    })
+
+    it('should return hasCheckLogs as false when no logs', () => {
+      const { result } = renderHook(() => useCheckLogs())
+
+      expect(result.current.hasCheckLogs).toBe(false)
+    })
+
+    it('should return checkLogCount from store', () => {
+      $checkLogs.set([mockCheckLog, { ...mockCheckLog, id: 'cl2' }])
+
+      const { result } = renderHook(() => useCheckLogs())
+
+      expect(result.current.checkLogCount).toBe(2)
+    })
+  })
+
+  describe('actions', () => {
+    it('should call checkLogActions.fetchLogs with vehicleId', async () => {
+      const spy = spyOn(checkLogActions, 'fetchLogs').mockResolvedValue(undefined)
+
+      const { result } = renderHook(() => useCheckLogs())
+      await result.current.fetchLogs('v1')
+
+      expect(spy).toHaveBeenCalledWith('v1')
+      spy.mockRestore()
+    })
+
+    it('should call checkLogActions.fetchStatuses with vehicleId', async () => {
+      const spy = spyOn(checkLogActions, 'fetchStatuses').mockResolvedValue(undefined)
+
+      const { result } = renderHook(() => useCheckLogs())
+      await result.current.fetchStatuses('v1')
+
+      expect(spy).toHaveBeenCalledWith('v1')
+      spy.mockRestore()
+    })
+
+    it('should call checkLogActions.create with vehicleId, checkTypeId and data', async () => {
+      const data = { completedAt: '2026-03-20', notes: 'OK' }
+      const spy = spyOn(checkLogActions, 'create').mockResolvedValue(mockCheckLog)
+
+      const { result } = renderHook(() => useCheckLogs())
+      await result.current.create('v1', 'ct1', data)
+
+      expect(spy).toHaveBeenCalledWith('v1', 'ct1', data)
+      spy.mockRestore()
+    })
+
+    it('should call checkLogActions.remove with vehicleId and id', async () => {
+      const spy = spyOn(checkLogActions, 'remove').mockResolvedValue(undefined)
+
+      const { result } = renderHook(() => useCheckLogs())
+      await result.current.remove('v1', 'cl1')
+
+      expect(spy).toHaveBeenCalledWith('v1', 'cl1')
+      spy.mockRestore()
+    })
+
+    it('should call checkLogActions.clearError', () => {
+      const spy = spyOn(checkLogActions, 'clearError')
+
+      const { result } = renderHook(() => useCheckLogs())
+      result.current.clearError()
+
+      expect(spy).toHaveBeenCalled()
+      spy.mockRestore()
+    })
+  })
+})

--- a/apps/web/src/features/check-logs/hooks/useCheckLogs.ts
+++ b/apps/web/src/features/check-logs/hooks/useCheckLogs.ts
@@ -1,0 +1,53 @@
+import { useStore } from '@nanostores/react'
+import { useCallback } from 'react'
+
+import type { CreateCheckLogSchema } from '../schemas'
+import {
+  $checkLogCount,
+  $checkLogs,
+  $checkStatuses,
+  $error,
+  $hasCheckLogs,
+  $isLoading,
+  checkLogActions
+} from '../store'
+import type { CheckLog, CheckStatusSummary } from '../types'
+
+export interface UseCheckLogsReturn {
+  logs: CheckLog[]
+  statuses: CheckStatusSummary[]
+  isLoading: boolean
+  error: string | null
+  hasCheckLogs: boolean
+  checkLogCount: number
+  fetchLogs: (vehicleId: string) => Promise<void>
+  fetchStatuses: (vehicleId: string) => Promise<void>
+  create: (vehicleId: string, checkTypeId: string, data: CreateCheckLogSchema) => Promise<CheckLog>
+  remove: (vehicleId: string, id: string) => Promise<void>
+  clearError: () => void
+}
+
+export const useCheckLogs = (): UseCheckLogsReturn => {
+  const fetchLogs = useCallback(async (vehicleId: string) => {
+    await checkLogActions.fetchLogs(vehicleId)
+  }, [])
+
+  const fetchStatuses = useCallback(async (vehicleId: string) => {
+    await checkLogActions.fetchStatuses(vehicleId)
+  }, [])
+
+  return {
+    logs: useStore($checkLogs),
+    statuses: useStore($checkStatuses),
+    isLoading: useStore($isLoading),
+    error: useStore($error),
+    hasCheckLogs: useStore($hasCheckLogs),
+    checkLogCount: useStore($checkLogCount),
+    fetchLogs,
+    fetchStatuses,
+    create: async (vehicleId, checkTypeId, data) =>
+      await checkLogActions.create(vehicleId, checkTypeId, data),
+    remove: async (vehicleId, id) => await checkLogActions.remove(vehicleId, id),
+    clearError: () => checkLogActions.clearError()
+  }
+}

--- a/apps/web/src/features/check-logs/store/checkLog.store.spec.ts
+++ b/apps/web/src/features/check-logs/store/checkLog.store.spec.ts
@@ -1,0 +1,268 @@
+import type { Mock } from 'bun:test'
+import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test'
+
+import { api } from '~/lib/apiRequest'
+import { cleanup } from '~/test-utils'
+
+import type { CheckLog, CheckStatusSummary } from '../types'
+
+import {
+  $checkLogCount,
+  $checkLogs,
+  $checkStatuses,
+  $error,
+  $hasCheckLogs,
+  $isLoading,
+  checkLogActions
+} from './checkLog.store'
+
+const mockCheckLog: CheckLog = {
+  id: 'cl1',
+  checkTypeId: 'ct1',
+  checkTypeName: 'Vidange',
+  completedAt: '2026-03-15',
+  notes: 'All good',
+  nextDueAt: '2026-03-22',
+  createdAt: '2026-03-15T10:00:00Z'
+}
+
+const mockCheckLog2: CheckLog = {
+  id: 'cl2',
+  checkTypeId: 'ct1',
+  checkTypeName: 'Vidange',
+  completedAt: '2026-03-10',
+  notes: null,
+  nextDueAt: '2026-03-17',
+  createdAt: '2026-03-10T10:00:00Z'
+}
+
+const mockStatusSummary: CheckStatusSummary = {
+  checkTypeId: 'ct1',
+  checkTypeName: 'Vidange',
+  intervalDays: 7,
+  lastCompletedAt: '2026-03-15',
+  nextDueAt: '2026-03-22',
+  status: 'on-time'
+}
+
+let getSpy: Mock<typeof api.get>
+let postSpy: Mock<typeof api.post>
+let deleteSpy: Mock<typeof api.delete>
+
+describe('CheckLog Store', () => {
+  beforeEach(() => {
+    cleanup()
+    document.body.innerHTML = ''
+
+    getSpy = spyOn(api, 'get')
+    postSpy = spyOn(api, 'post')
+    deleteSpy = spyOn(api, 'delete')
+
+    $checkLogs.set([])
+    $checkStatuses.set([])
+    $isLoading.set(false)
+    $error.set(null)
+  })
+
+  afterEach(() => {
+    getSpy.mockRestore()
+    postSpy.mockRestore()
+    deleteSpy.mockRestore()
+  })
+
+  describe('State Atoms', () => {
+    it('should initialize $checkLogs with empty array', () => {
+      expect($checkLogs.get()).toEqual([])
+    })
+
+    it('should initialize $checkStatuses with empty array', () => {
+      expect($checkStatuses.get()).toEqual([])
+    })
+
+    it('should initialize $isLoading with false', () => {
+      expect($isLoading.get()).toBe(false)
+    })
+
+    it('should initialize $error with null', () => {
+      expect($error.get()).toBe(null)
+    })
+  })
+
+  describe('Computed Values', () => {
+    it('should return false for $hasCheckLogs when empty', () => {
+      expect($hasCheckLogs.get()).toBe(false)
+    })
+
+    it('should return true for $hasCheckLogs when has items', () => {
+      $checkLogs.set([mockCheckLog])
+
+      expect($hasCheckLogs.get()).toBe(true)
+    })
+
+    it('should return correct $checkLogCount', () => {
+      expect($checkLogCount.get()).toBe(0)
+
+      $checkLogs.set([mockCheckLog, mockCheckLog2])
+
+      expect($checkLogCount.get()).toBe(2)
+    })
+  })
+
+  describe('checkLogActions', () => {
+    describe('fetchLogs', () => {
+      it('should fetch and set check logs on success', async () => {
+        const apiResponse = [mockCheckLog, mockCheckLog2]
+
+        getSpy.mockResolvedValueOnce({ data: apiResponse, success: true })
+
+        await checkLogActions.fetchLogs('vehicle123')
+
+        expect(getSpy).toHaveBeenCalledWith('/vehicles/vehicle123/check-logs')
+        expect($checkLogs.get()).toEqual(apiResponse)
+      })
+
+      it('should set error on failure', async () => {
+        const errorMessage = 'Failed to fetch logs'
+
+        getSpy.mockRejectedValueOnce(new Error(errorMessage))
+
+        await checkLogActions.fetchLogs('vehicle123')
+
+        expect(getSpy).toHaveBeenCalledWith('/vehicles/vehicle123/check-logs')
+        expect($error.get()).toBe(errorMessage)
+      })
+
+      it('should manage loading state during fetch', async () => {
+        const apiResponse = { data: [mockCheckLog], success: true }
+
+        getSpy.mockResolvedValueOnce(apiResponse)
+
+        const fetchPromise = checkLogActions.fetchLogs('vehicle123')
+
+        expect($isLoading.get()).toBe(true)
+
+        await fetchPromise
+
+        expect($isLoading.get()).toBe(false)
+      })
+    })
+
+    describe('fetchStatuses', () => {
+      it('should fetch and set check statuses on success', async () => {
+        const apiResponse = [mockStatusSummary]
+
+        getSpy.mockResolvedValueOnce({ data: apiResponse, success: true })
+
+        await checkLogActions.fetchStatuses('vehicle123')
+
+        expect(getSpy).toHaveBeenCalledWith('/vehicles/vehicle123/check-status')
+        expect($checkStatuses.get()).toEqual(apiResponse)
+      })
+
+      it('should set error on failure', async () => {
+        const errorMessage = 'Failed to fetch statuses'
+
+        getSpy.mockRejectedValueOnce(new Error(errorMessage))
+
+        await checkLogActions.fetchStatuses('vehicle123')
+
+        expect(getSpy).toHaveBeenCalledWith('/vehicles/vehicle123/check-status')
+        expect($error.get()).toBe(errorMessage)
+      })
+    })
+
+    describe('create', () => {
+      it('should create check log, append to list, and refresh statuses', async () => {
+        const newCheckLog = {
+          completedAt: '2026-03-20',
+          notes: 'New log'
+        }
+        const createdCheckLog = {
+          ...mockCheckLog,
+          ...newCheckLog,
+          checkTypeId: 'ct1',
+          id: 'cl3',
+          nextDueAt: '2026-03-27',
+          createdAt: '2026-03-20T10:00:00Z'
+        }
+        const statusSummary = {
+          ...mockStatusSummary,
+          lastCompletedAt: '2026-03-20',
+          nextDueAt: '2026-03-27',
+          status: 'on-time' as const
+        }
+
+        postSpy.mockResolvedValueOnce({ data: createdCheckLog, success: true })
+        getSpy.mockResolvedValueOnce({ data: [statusSummary], success: true })
+
+        await checkLogActions.create('vehicle123', 'ct1', newCheckLog)
+
+        expect(postSpy).toHaveBeenCalledWith('/vehicles/vehicle123/check-logs', {
+          ...newCheckLog,
+          checkTypeId: 'ct1'
+        })
+        expect(getSpy).toHaveBeenCalledWith('/vehicles/vehicle123/check-status')
+        expect($checkLogs.get()).toContainEqual(createdCheckLog)
+        expect($checkStatuses.get()).toContainEqual(statusSummary)
+      })
+
+      it('should set error on creation failure', async () => {
+        const newCheckLog = {
+          completedAt: '2026-03-20',
+          notes: 'New log'
+        }
+        const errorMessage = 'Failed to create log'
+
+        postSpy.mockRejectedValueOnce(new Error(errorMessage))
+
+        await expect(checkLogActions.create('vehicle123', 'ct1', newCheckLog)).rejects.toThrow(
+          errorMessage
+        )
+
+        expect(postSpy).toHaveBeenCalledWith('/vehicles/vehicle123/check-logs', {
+          ...newCheckLog,
+          checkTypeId: 'ct1'
+        })
+        expect($error.get()).toBe(errorMessage)
+      })
+    })
+
+    describe('remove', () => {
+      it('should delete check log, remove from list, and refresh statuses', async () => {
+        $checkLogs.set([mockCheckLog, mockCheckLog2])
+
+        deleteSpy.mockResolvedValueOnce({ success: true })
+        getSpy.mockResolvedValueOnce({ data: [mockStatusSummary], success: true })
+
+        await checkLogActions.remove('vehicle123', 'cl1')
+
+        expect(deleteSpy).toHaveBeenCalledWith('/vehicles/vehicle123/check-logs/cl1')
+        expect(getSpy).toHaveBeenCalledWith('/vehicles/vehicle123/check-status')
+        expect($checkLogs.get()).not.toContainEqual(mockCheckLog)
+        expect($checkStatuses.get()).toContainEqual(mockStatusSummary)
+      })
+
+      it('should set error on deletion failure', async () => {
+        $checkLogs.set([mockCheckLog, mockCheckLog2])
+        const errorMessage = 'Failed to delete log'
+
+        deleteSpy.mockRejectedValueOnce(new Error(errorMessage))
+
+        await expect(checkLogActions.remove('vehicle123', 'cl1')).rejects.toThrow(errorMessage)
+
+        expect(deleteSpy).toHaveBeenCalledWith('/vehicles/vehicle123/check-logs/cl1')
+        expect($error.get()).toBe(errorMessage)
+      })
+    })
+
+    describe('clearError', () => {
+      it('should clear error state', () => {
+        $error.set('Some error')
+
+        checkLogActions.clearError()
+
+        expect($error.get()).toBe(null)
+      })
+    })
+  })
+})

--- a/apps/web/src/features/check-logs/store/checkLog.store.ts
+++ b/apps/web/src/features/check-logs/store/checkLog.store.ts
@@ -1,0 +1,99 @@
+import { atom, computed } from 'nanostores'
+
+import { createCheckLog, deleteCheckLog, getCheckLogs, getCheckStatusSummary } from '../api'
+import type { CreateCheckLogSchema } from '../schemas'
+import type { CheckLog, CheckStatusSummary } from '../types'
+
+export const $checkLogs = atom<CheckLog[]>([])
+export const $checkStatuses = atom<CheckStatusSummary[]>([])
+export const $isLoading = atom<boolean>(false)
+export const $error = atom<string | null>(null)
+
+export const $hasCheckLogs = computed($checkLogs, checkLogs => checkLogs.length > 0)
+export const $checkLogCount = computed($checkLogs, checkLogs => checkLogs.length)
+
+export const checkLogActions = {
+  async fetchLogs(vehicleId: string) {
+    $isLoading.set(true)
+    $error.set(null)
+
+    try {
+      const response = await getCheckLogs(vehicleId)
+
+      $checkLogs.set(response)
+
+      return response
+    } catch (error) {
+      $checkLogs.set([])
+      $error.set(error instanceof Error ? error.message : 'Unknown error')
+    } finally {
+      $isLoading.set(false)
+    }
+  },
+
+  async fetchStatuses(vehicleId: string) {
+    $isLoading.set(true)
+    $error.set(null)
+
+    try {
+      const response = await getCheckStatusSummary(vehicleId)
+
+      $checkStatuses.set(response)
+
+      return response
+    } catch (error) {
+      $checkStatuses.set([])
+      $error.set(error instanceof Error ? error.message : 'Unknown error')
+    } finally {
+      $isLoading.set(false)
+    }
+  },
+
+  async create(
+    vehicleId: string,
+    checkTypeId: string,
+    data: CreateCheckLogSchema
+  ): Promise<CheckLog> {
+    $isLoading.set(true)
+    $error.set(null)
+
+    try {
+      const response = await createCheckLog(vehicleId, { ...data, checkTypeId })
+
+      $checkLogs.set([...$checkLogs.get(), response])
+
+      await checkLogActions.fetchStatuses(vehicleId)
+
+      return response
+    } catch (error) {
+      $error.set(error instanceof Error ? error.message : 'Unknown error')
+
+      throw error
+    } finally {
+      $isLoading.set(false)
+    }
+  },
+
+  async remove(vehicleId: string, id: string): Promise<void> {
+    $isLoading.set(true)
+    $error.set(null)
+
+    try {
+      await deleteCheckLog(vehicleId, id)
+
+      $checkLogs.set($checkLogs.get().filter(log => log.id !== id))
+
+      await checkLogActions.fetchStatuses(vehicleId)
+    } catch (error) {
+      $error.set(error instanceof Error ? error.message : 'Unknown error')
+
+      throw error
+    } finally {
+      $isLoading.set(false)
+    }
+  },
+
+  clearError() {
+    $error.set(null)
+  }
+}

--- a/apps/web/src/features/check-logs/store/index.ts
+++ b/apps/web/src/features/check-logs/store/index.ts
@@ -1,0 +1,9 @@
+export {
+  $checkLogCount,
+  $checkLogs,
+  $checkStatuses,
+  $error,
+  $hasCheckLogs,
+  $isLoading,
+  checkLogActions
+} from './checkLog.store'

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -56,19 +56,19 @@
 
 #### Phase 6: Frontend State & Hook
 
-- [ ] Nanostores store + tests
-- [ ] Custom hook (useCheckLogs) + tests
+- [x] Nanostores store + tests
+- [x] Custom hook (useCheckLogs) + tests
 
 #### Phase 7: Frontend UI Components
 
-- [ ] CheckStatusBadge + tests
-- [ ] LogCheckForm + tests
-- [ ] LogCheckDialog + tests
-- [ ] CheckLogCard + tests
-- [ ] CheckLogList + tests
-- [ ] CheckTypeFilter + tests
-- [ ] DeleteCheckLogDialog + tests
-- [ ] CheckLogContainer + tests
+- [x] CheckStatusBadge + tests
+- [x] LogCheckForm + tests
+- [x] LogCheckDialog + tests
+- [x] CheckLogCard + tests
+- [x] CheckLogList + tests
+- [x] CheckTypeFilter + tests
+- [x] DeleteCheckLogDialog + tests
+- [x] CheckLogContainer + tests
 
 ---
 


### PR DESCRIPTION
## Summary

- Nanostores store with cascading state updates (create/delete refresh statuses)
- useCheckLogs React hook wrapping store
- 8 UI components: CheckStatusBadge, LogCheckForm, LogCheckDialog, CheckLogCard, CheckLogList, CheckTypeFilter, DeleteCheckLogDialog, CheckLogContainer

## Block 3 of 4 — Feature 04: Check Logging

Covers Phases 6-7 (Frontend State + Components). Next: Block 4 (integration with CheckType components, Astro page, nav link).

## Test plan

- [x] All existing tests still pass (1047 total)
- [x] 17 new store tests (atoms, computed, all actions)
- [x] 12 new hook tests (reactive state + action delegation)
- [x] 4 new CheckStatusBadge tests (all 4 status variants)
- [x] 6 new LogCheckForm tests (fields, date max, defaults)
- [x] 6 new LogCheckDialog tests (dialog, title, form, buttons)
- [x] 7 new CheckLogCard tests (rendering, notes, delete)
- [x] 4 new CheckLogList tests (grid, empty state)
- [x] 6 new CheckTypeFilter tests (options, selection, onChange)
- [x] 5 new DeleteCheckLogDialog tests (confirm/cancel)
- [x] 8 new CheckLogContainer tests (loading, filter, delete, error)
- [x] Typecheck, lint, format all pass