### PR TITLE
feat(check-logging): add integration, page, and UI polish (Block 4)

### DIFF
--- a/apps/web/src/features/check-logs/components/CheckLogCard.tsx
+++ b/apps/web/src/features/check-logs/components/CheckLogCard.tsx
@@ -18,26 +18,26 @@ export const CheckLogCard = ({ checkLog, onDelete }: CheckLogCardProps) => (
           {checkLog.checkTypeName}
         </h2>
       </header>
-      <div className='text-base-content/70 flex flex-col gap-1 text-sm'>
-        <p className='flex items-center gap-2'>
+      <ul className='text-base-content/70 flex flex-col gap-1 text-sm'>
+        <li className='flex items-center gap-2'>
           <Calendar size={14} className='shrink-0' />
           Effectué le {checkLog.completedAt}
-        </p>
-        <p className='flex items-center gap-2'>
+        </li>
+        <li className='flex items-center gap-2'>
           <Calendar size={14} className='shrink-0' />
           Prochain le {checkLog.nextDueAt}
-        </p>
-      </div>
+        </li>
+      </ul>
       {checkLog.notes && (
         <p className='text-base-content/60 line-clamp-2 text-sm'>{checkLog.notes}</p>
       )}
       <footer className='card-actions justify-end'>
         <Button
           variant='destructive'
-          className='btn-sm btn-outline gap-1'
+          className='btn-xs btn-outline gap-1'
           onClick={() => onDelete(checkLog)}
         >
-          <Trash2 size={14} />
+          <Trash2 size={12} />
           Supprimer
         </Button>
       </footer>

--- a/apps/web/src/features/check-logs/components/CheckLogContainer.tsx
+++ b/apps/web/src/features/check-logs/components/CheckLogContainer.tsx
@@ -1,3 +1,4 @@
+import { ClipboardList } from 'lucide-react'
 import { useEffect, useState } from 'react'
 
 import { useCheckTypes } from '~/features/check-types'
@@ -67,14 +68,25 @@ export const CheckLogContainer = () => {
   }
 
   return (
-    <section>
-      <h1>Historique des contrôles</h1>
-      {error && <p className='alert alert-error'>{error}</p>}
-      <CheckTypeFilter
-        checkTypes={checkTypes}
-        selectedCheckTypeId={selectedCheckTypeId}
-        onChange={setSelectedCheckTypeId}
-      />
+    <section className='mx-auto max-w-6xl p-6'>
+      <header className='mb-6'>
+        <h1 className='text-base-content flex items-center gap-2 text-2xl font-bold'>
+          <ClipboardList size={24} className='text-primary' />
+          Historique des contrôles
+        </h1>
+      </header>
+      {error && (
+        <p className='alert alert-error' role='alert'>
+          {error}
+        </p>
+      )}
+      <aside className='mb-6'>
+        <CheckTypeFilter
+          checkTypes={checkTypes}
+          selectedCheckTypeId={selectedCheckTypeId}
+          onChange={setSelectedCheckTypeId}
+        />
+      </aside>
       <CheckLogList checkLogs={filteredLogs} onDelete={setDeletingCheckLog} />
       {deletingCheckLog && (
         <DeleteCheckLogDialog

--- a/apps/web/src/features/check-logs/components/CheckStatusBadge.spec.tsx
+++ b/apps/web/src/features/check-logs/components/CheckStatusBadge.spec.tsx
@@ -37,12 +37,12 @@ describe('CheckStatusBadge', () => {
     expect(badge).toHaveClass('badge-error')
   })
 
-  it('should render "Jamais effectué" with badge-neutral for never status', () => {
+  it('should render "Jamais effectué" with badge-info for never status', () => {
     render(<CheckStatusBadge status='never' />)
 
     const badge = screen.getByText('Jamais effectué')
 
     expect(badge).toBeInTheDocument()
-    expect(badge).toHaveClass('badge-neutral')
+    expect(badge).toHaveClass('badge-info')
   })
 })

--- a/apps/web/src/features/check-logs/components/CheckStatusBadge.tsx
+++ b/apps/web/src/features/check-logs/components/CheckStatusBadge.tsx
@@ -14,7 +14,7 @@ export const CheckStatusBadge = ({ status }: CheckStatusBadgeProps) => {
     'on-time': { className: 'badge-success', label: 'À jour' },
     'due-soon': { className: 'badge-warning', label: 'Bientôt' },
     overdue: { className: 'badge-error', label: 'En retard' },
-    never: { className: 'badge-neutral', label: 'Jamais effectué' }
+    never: { className: 'badge-info', label: 'Jamais effectué' }
   }
 
   return (

--- a/apps/web/src/features/check-logs/components/index.ts
+++ b/apps/web/src/features/check-logs/components/index.ts
@@ -1,0 +1,3 @@
+export { CheckLogContainer } from './CheckLogContainer'
+export { CheckStatusBadge } from './CheckStatusBadge'
+export { LogCheckDialog } from './LogCheckDialog'

--- a/apps/web/src/features/check-logs/index.ts
+++ b/apps/web/src/features/check-logs/index.ts
@@ -1,0 +1,3 @@
+export { CheckLogContainer, CheckStatusBadge, LogCheckDialog } from './components'
+export { useCheckLogs, type UseCheckLogsReturn } from './hooks'
+export type { CheckLog, CheckStatus, CheckStatusSummary, CreateCheckLogInput } from './types'

--- a/apps/web/src/features/check-types/components/CheckTypeCard.spec.tsx
+++ b/apps/web/src/features/check-types/components/CheckTypeCard.spec.tsx
@@ -87,4 +87,63 @@ describe('CheckTypeCard', () => {
 
     expect(onDelete).toHaveBeenCalledWith(mockCheckType)
   })
+
+  it('should render CheckStatusBadge when status is provided', () => {
+    const actions = mock(() => {})
+
+    render(
+      <CheckTypeCard
+        checkType={mockCheckType}
+        onEdit={actions}
+        onDelete={actions}
+        status='on-time'
+      />
+    )
+
+    expect(screen.getByText(/à jour/i)).toBeInTheDocument()
+  })
+
+  it('should not render CheckStatusBadge when status is not provided', () => {
+    const actions = mock(() => {})
+
+    render(<CheckTypeCard checkType={mockCheckType} onEdit={actions} onDelete={actions} />)
+
+    expect(screen.queryByText(/à jour/i)).toBeNull()
+  })
+
+  it('should render log button when onLog is provided', () => {
+    const actions = mock(() => {})
+
+    render(
+      <CheckTypeCard
+        checkType={mockCheckType}
+        onEdit={actions}
+        onDelete={actions}
+        onLog={actions}
+      />
+    )
+
+    expect(screen.getByRole('button', { name: /journaliser/i })).toBeInTheDocument()
+  })
+
+  it('should not render log button when onLog is not provided', () => {
+    const actions = mock(() => {})
+
+    render(<CheckTypeCard checkType={mockCheckType} onEdit={actions} onDelete={actions} />)
+
+    expect(screen.queryByRole('button', { name: /journaliser/i })).toBeNull()
+  })
+
+  it('should call onLog with checkType when log button clicked', () => {
+    const onLog = mock(() => {})
+    const actions = mock(() => {})
+
+    render(
+      <CheckTypeCard checkType={mockCheckType} onEdit={actions} onDelete={actions} onLog={onLog} />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /journaliser/i }))
+
+    expect(onLog).toHaveBeenCalledWith(mockCheckType)
+  })
 })

--- a/apps/web/src/features/check-types/components/CheckTypeCard.tsx
+++ b/apps/web/src/features/check-types/components/CheckTypeCard.tsx
@@ -1,6 +1,8 @@
 import { ClipboardCheck, Pencil, Trash2 } from 'lucide-react'
 
 import { Button } from '~/components/ui'
+import { CheckStatusBadge } from '~/features/check-logs/components/CheckStatusBadge'
+import type { CheckStatus } from '~/features/check-logs/types'
 
 import type { CheckType } from '../types'
 
@@ -8,39 +10,60 @@ export interface CheckTypeCardProps {
   checkType: CheckType
   onEdit: (checkType: CheckType) => void
   onDelete: (checkType: CheckType) => void
+  status?: CheckStatus
+  onLog?: (checkType: CheckType) => void
 }
 
-export const CheckTypeCard = ({ checkType, onEdit, onDelete }: CheckTypeCardProps) => {
-  const formattedInterval = `Tous les ${checkType.intervalDays} jours`
-
-  return (
-    <article className='card card-border card-sm animate-fade-in-up border-l-primary bg-base-200 hover:shadow-primary/5 border-l-4 transition-all duration-200 hover:-translate-y-0.5 hover:shadow-lg'>
-      <section className='card-body gap-3'>
-        <header className='flex flex-wrap items-start gap-2'>
-          <h2 className='card-title gap-2'>
-            <ClipboardCheck size={18} className='text-primary/70 shrink-0' />
-            {checkType.name}
-          </h2>
-          <span className='badge badge-neutral shrink-0'>{formattedInterval}</span>
-        </header>
-        {checkType.description && (
-          <p className='text-base-content/60 line-clamp-2 text-sm'>{checkType.description}</p>
+export const CheckTypeCard = ({
+  checkType,
+  onEdit,
+  onDelete,
+  status,
+  onLog
+}: CheckTypeCardProps) => (
+  <article className='card card-border card-sm animate-fade-in-up border-l-primary bg-base-200 hover:shadow-primary/5 border-l-4 transition-all duration-200 hover:-translate-y-0.5 hover:shadow-lg'>
+    <section className='card-body gap-3'>
+      <header>
+        <h2 className='card-title gap-2'>
+          <ClipboardCheck size={18} className='text-primary/70 shrink-0' />
+          {checkType.name}
+        </h2>
+      </header>
+      <div className='flex flex-wrap items-center gap-1.5'>
+        <span className='text-base-content/50 text-xs'>
+          Tous les {checkType.intervalDays} jours
+        </span>
+        {status && <CheckStatusBadge status={status} />}
+      </div>
+      {checkType.description && (
+        <p className='text-base-content/60 line-clamp-2 text-sm'>{checkType.description}</p>
+      )}
+      <footer className='card-actions items-center justify-between'>
+        {onLog && (
+          <Button variant='outline' className='btn-sm gap-1' onClick={() => onLog(checkType)}>
+            <ClipboardCheck size={14} />
+            Journaliser
+          </Button>
         )}
-        <footer className='card-actions justify-end'>
-          <Button variant='ghost' className='btn-sm gap-1' onClick={() => onEdit(checkType)}>
+        <nav className='ml-auto flex gap-1'>
+          <Button
+            variant='ghost'
+            className='btn-xs btn-square'
+            onClick={() => onEdit(checkType)}
+            aria-label={`Modifier ${checkType.name}`}
+          >
             <Pencil size={14} />
-            Modifier
           </Button>
           <Button
             variant='destructive'
-            className='btn-sm btn-outline gap-1'
+            className='btn-xs btn-square btn-outline'
             onClick={() => onDelete(checkType)}
+            aria-label={`Supprimer ${checkType.name}`}
           >
             <Trash2 size={14} />
-            Supprimer
           </Button>
-        </footer>
-      </section>
-    </article>
-  )
-}
+        </nav>
+      </footer>
+    </section>
+  </article>
+)

--- a/apps/web/src/features/check-types/components/CheckTypeCard.tsx
+++ b/apps/web/src/features/check-types/components/CheckTypeCard.tsx
@@ -45,7 +45,7 @@ export const CheckTypeCard = ({
             Journaliser
           </Button>
         )}
-        <nav className='ml-auto flex gap-1'>
+        <div className='ml-auto flex gap-1'>
           <Button
             variant='ghost'
             className='btn-xs btn-square'
@@ -62,7 +62,7 @@ export const CheckTypeCard = ({
           >
             <Trash2 size={14} />
           </Button>
-        </nav>
+        </div>
       </footer>
     </section>
   </article>

--- a/apps/web/src/features/check-types/components/CheckTypeContainer.spec.tsx
+++ b/apps/web/src/features/check-types/components/CheckTypeContainer.spec.tsx
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from 'bun:te
 // Direct store imports: bun:test mock.module leaks globally across files,
 // so mocking ~/features/vehicles breaks the vehicles feature's own tests.
 // Using internal paths for test state setup is the pragmatic workaround.
+import { $checkStatuses, checkLogActions } from '~/features/check-logs/store'
 import type { Vehicle } from '~/features/vehicles'
 import {
   $isLoading as $isVehicleLoading,
@@ -65,6 +66,8 @@ describe('CheckTypeContainer', () => {
   let createSpy: ReturnType<typeof spyOn>
   let updateSpy: ReturnType<typeof spyOn>
   let removeSpy: ReturnType<typeof spyOn>
+  let fetchStatusesSpy: ReturnType<typeof spyOn>
+  let createLogSpy: ReturnType<typeof spyOn>
 
   beforeEach(() => {
     cleanup()
@@ -73,6 +76,7 @@ describe('CheckTypeContainer', () => {
     $vehicle.set(null)
     $isVehicleLoading.set(false)
     $checkTypes.set([])
+    $checkStatuses.set([])
     $isLoading.set(false)
     $error.set(null)
 
@@ -81,6 +85,16 @@ describe('CheckTypeContainer', () => {
     createSpy = spyOn(checkTypeActions, 'create').mockResolvedValue(mockCheckTypes[0])
     updateSpy = spyOn(checkTypeActions, 'update').mockResolvedValue(mockCheckTypes[0])
     removeSpy = spyOn(checkTypeActions, 'remove').mockResolvedValue(undefined)
+    fetchStatusesSpy = spyOn(checkLogActions, 'fetchStatuses').mockResolvedValue(undefined)
+    createLogSpy = spyOn(checkLogActions, 'create').mockResolvedValue({
+      id: 'cl-1',
+      checkTypeId: 'ct-1',
+      checkTypeName: "Niveau d'huile",
+      completedAt: '2026-03-28',
+      notes: null,
+      nextDueAt: '2026-04-04',
+      createdAt: '2026-03-28T10:00:00Z'
+    })
   })
 
   afterEach(() => {
@@ -89,6 +103,8 @@ describe('CheckTypeContainer', () => {
     createSpy.mockRestore()
     updateSpy.mockRestore()
     removeSpy.mockRestore()
+    fetchStatusesSpy.mockRestore()
+    createLogSpy.mockRestore()
   })
 
   describe('loading + initial fetch', () => {
@@ -238,7 +254,7 @@ describe('CheckTypeContainer', () => {
       await act(async () => {
         render(<CheckTypeContainer />)
       })
-      fireEvent.click(screen.getAllByRole('button', { name: 'Modifier' })[0])
+      fireEvent.click(screen.getAllByRole('button', { name: /modifier/i })[0])
 
       expect(screen.getByLabelText('Nom')).toHaveValue(`Niveau d'huile`)
       expect(screen.getByLabelText('Intervalle (jours)')).toHaveValue(7)
@@ -254,7 +270,7 @@ describe('CheckTypeContainer', () => {
       await act(async () => {
         render(<CheckTypeContainer />)
       })
-      fireEvent.click(screen.getAllByRole('button', { name: 'Modifier' })[0])
+      fireEvent.click(screen.getAllByRole('button', { name: /modifier/i })[0])
       await user.clear(screen.getByLabelText('Nom'))
       await user.type(screen.getByLabelText('Nom'), 'Updated Check Type')
       fireEvent.click(screen.getByRole('button', { name: 'Enregistrer' }))
@@ -276,7 +292,7 @@ describe('CheckTypeContainer', () => {
       await act(async () => {
         render(<CheckTypeContainer />)
       })
-      fireEvent.click(screen.getAllByRole('button', { name: 'Modifier' })[0])
+      fireEvent.click(screen.getAllByRole('button', { name: /modifier/i })[0])
       fireEvent.click(screen.getByRole('button', { name: 'Annuler' }))
 
       expect(screen.getByText(`Niveau d'huile`)).toBeVisible()
@@ -295,7 +311,7 @@ describe('CheckTypeContainer', () => {
       await act(async () => {
         render(<CheckTypeContainer />)
       })
-      fireEvent.click(screen.getAllByRole('button', { name: 'Modifier' })[0])
+      fireEvent.click(screen.getAllByRole('button', { name: /modifier/i })[0])
       await user.clear(screen.getByLabelText('Nom'))
       await user.type(screen.getByLabelText('Nom'), 'Updated Check Type')
       fireEvent.click(screen.getByRole('button', { name: 'Enregistrer' }))
@@ -325,7 +341,7 @@ describe('CheckTypeContainer', () => {
       await act(async () => {
         render(<CheckTypeContainer />)
       })
-      fireEvent.click(screen.getAllByRole('button', { name: 'Supprimer' })[0])
+      fireEvent.click(screen.getAllByRole('button', { name: /supprimer/i })[0])
 
       expect(screen.getByText('Supprimer le type de contrôle')).toBeVisible()
       expect(
@@ -344,8 +360,8 @@ describe('CheckTypeContainer', () => {
       await act(async () => {
         render(<CheckTypeContainer />)
       })
-      fireEvent.click(screen.getAllByRole('button', { name: 'Supprimer' })[0])
-      const deleteButtons = screen.getAllByRole('button', { name: 'Supprimer' })
+      fireEvent.click(screen.getAllByRole('button', { name: /supprimer/i })[0])
+      const deleteButtons = screen.getAllByRole('button', { name: /supprimer/i })
       await user.click(deleteButtons[deleteButtons.length - 1]) // Click the confirm button in the dialog
 
       await waitFor(() => {
@@ -363,7 +379,7 @@ describe('CheckTypeContainer', () => {
       await act(async () => {
         render(<CheckTypeContainer />)
       })
-      fireEvent.click(screen.getAllByRole('button', { name: 'Supprimer' })[0])
+      fireEvent.click(screen.getAllByRole('button', { name: /supprimer/i })[0])
       await user.click(screen.getByRole('button', { name: 'Annuler' }))
 
       await waitFor(() => {
@@ -454,10 +470,94 @@ describe('CheckTypeContainer', () => {
       updateSpy.mockRejectedValueOnce(new Error(errorMessage))
 
       render(<CheckTypeContainer />)
-      fireEvent.click(screen.getAllByRole('button', { name: 'Modifier' })[0])
+      fireEvent.click(screen.getAllByRole('button', { name: /modifier/i })[0])
       fireEvent.click(screen.getByRole('button', { name: 'Enregistrer' }))
 
       await waitFor(() => expect(screen.getByText(errorMessage)).toBeVisible())
+    })
+  })
+
+  describe('check log integration', () => {
+    it('should render status badges on check type cards', async () => {
+      $isLoading.set(false)
+      $vehicle.set(mockVehicle)
+      $checkTypes.set(mockCheckTypes)
+      $checkStatuses.set([
+        {
+          checkTypeId: 'ct-1',
+          checkTypeName: `Niveau d'huile`,
+          intervalDays: 7,
+          lastCompletedAt: '2026-01-01',
+          nextDueAt: '2026-01-08',
+          status: 'overdue'
+        },
+        {
+          checkTypeId: 'ct-2',
+          checkTypeName: `Niveau de liquide de refroidissement`,
+          intervalDays: 7,
+          lastCompletedAt: '2026-01-10T00:00:00.000Z',
+          nextDueAt: '2026-01-17T00:00:00.000Z',
+          status: 'on-time'
+        }
+      ])
+
+      await act(async () => {
+        render(<CheckTypeContainer />)
+      })
+
+      expect(screen.getByText('En retard')).toBeVisible()
+      expect(screen.getByText('À jour')).toBeVisible()
+    })
+
+    it('should render "Journaliser" button on each card', async () => {
+      $vehicle.set(mockVehicle)
+      $isLoading.set(false)
+      $checkTypes.set(mockCheckTypes)
+
+      await act(async () => {
+        render(<CheckTypeContainer />)
+      })
+
+      const logButtons = screen.getAllByRole('button', { name: 'Journaliser' })
+      expect(logButtons).toHaveLength(mockCheckTypes.length)
+    })
+
+    it('should open LogCheckDialog when Journaliser is clicked', async () => {
+      $isLoading.set(false)
+      $vehicle.set(mockVehicle)
+      $checkTypes.set(mockCheckTypes)
+
+      await act(async () => {
+        render(<CheckTypeContainer />)
+      })
+
+      const logButtons = screen.getAllByRole('button', { name: /journaliser/i })
+      fireEvent.click(logButtons[0])
+
+      await waitFor(() => {
+        expect(screen.getByText(/Enregistrer un contrôle/i)).toBeVisible()
+      })
+    })
+
+    it('should show success message after logging a check', async () => {
+      $isLoading.set(false)
+      $vehicle.set(mockVehicle)
+      $checkTypes.set(mockCheckTypes)
+
+      await act(async () => {
+        render(<CheckTypeContainer />)
+      })
+
+      const logButtons = screen.getAllByRole('button', { name: /journaliser/i })
+      fireEvent.click(logButtons[0])
+
+      await waitFor(() => {
+        expect(screen.getByText(/Enregistrer un contrôle/i)).toBeVisible()
+      })
+
+      fireEvent.click(screen.getByRole('button', { name: /^Enregistrer$/i }))
+
+      await waitFor(() => expect(screen.getByText('Contrôle enregistré avec succès')).toBeVisible())
     })
   })
 })

--- a/apps/web/src/features/check-types/components/CheckTypeContainer.tsx
+++ b/apps/web/src/features/check-types/components/CheckTypeContainer.tsx
@@ -4,6 +4,9 @@ import { useEffect, useState } from 'react'
 import { useForm } from 'react-hook-form'
 
 import { Button, FormWrapper } from '~/components/ui'
+import type { CheckStatus } from '~/features/check-logs'
+import { LogCheckDialog, useCheckLogs } from '~/features/check-logs'
+import type { CreateCheckLogSchema } from '~/features/check-logs/schemas'
 import { useVehicle } from '~/features/vehicles'
 import { redirect } from '~/utils/navigation'
 
@@ -24,6 +27,8 @@ export const CheckTypeContainer = () => {
   const [hasFetchedVehicle, setHasFetchedVehicle] = useState(false)
   const [editingCheckType, setEditingCheckType] = useState<CheckType | null>(null)
   const [deletingCheckType, setDeletingCheckType] = useState<CheckType | null>(null)
+  const [loggingCheckType, setLoggingCheckType] = useState<CheckType | null>(null)
+  const [successMessage, setSuccessMessage] = useState<string | null>(null)
   const { vehicle, fetchVehicle, hasVehicle } = useVehicle()
   const {
     checkTypes,
@@ -34,6 +39,7 @@ export const CheckTypeContainer = () => {
     remove,
     update
   } = useCheckTypes()
+  const { statuses, fetchStatuses, create: createLog } = useCheckLogs()
 
   const form = useForm<CreateCheckTypeSchema>({
     defaultValues: {},
@@ -54,8 +60,9 @@ export const CheckTypeContainer = () => {
   useEffect(() => {
     if (hasVehicle && vehicle) {
       fetchByVehicle(vehicle.id)
+      fetchStatuses(vehicle.id)
     }
-  }, [hasVehicle, vehicle, fetchByVehicle])
+  }, [hasVehicle, vehicle, fetchByVehicle, fetchStatuses])
 
   useEffect(() => {
     if (mode !== 'loading') return
@@ -93,6 +100,19 @@ export const CheckTypeContainer = () => {
       setServerError(error instanceof Error ? error.message : 'Une erreur est survenue')
     }
   })
+
+  const handleLogSubmit = async (data: CreateCheckLogSchema) => {
+    if (!vehicle || !loggingCheckType) return
+
+    try {
+      await createLog(vehicle.id, loggingCheckType.id, data)
+      setLoggingCheckType(null)
+      setSuccessMessage('Contrôle enregistré avec succès')
+      setTimeout(() => setSuccessMessage(null), 3000)
+    } catch (error) {
+      setServerError(error instanceof Error ? error.message : 'Une erreur est survenue')
+    }
+  }
 
   const handleDeleteConfirm = async () => {
     if (!vehicle || !deletingCheckType) return
@@ -146,7 +166,7 @@ export const CheckTypeContainer = () => {
 
   if (mode === 'create') {
     return (
-      <section className='mx-auto max-w-lg p-6'>
+      <section className='mx-auto max-w-2xl p-6'>
         <h1 className='text-base-content mb-8 flex items-center justify-center gap-3 text-center text-4xl font-bold'>
           <PlusCircle size={32} className='text-primary' />
           Ajouter un type de contrôle
@@ -168,7 +188,7 @@ export const CheckTypeContainer = () => {
 
   if (mode === 'edit') {
     return (
-      <section className='mx-auto max-w-lg p-6'>
+      <section className='mx-auto max-w-2xl p-6'>
         <h1 className='text-base-content mb-8 flex items-center justify-center gap-3 text-center text-4xl font-bold'>
           <PencilLine size={32} className='text-primary' />
           Modifier le type de contrôle
@@ -192,9 +212,13 @@ export const CheckTypeContainer = () => {
     suggestion => !checkTypes.some(checkType => checkType.name === suggestion.name)
   )
 
+  const statusesMap = new Map<string, CheckStatus>(
+    statuses.map(statusMap => [statusMap.checkTypeId, statusMap.status])
+  )
+
   if (mode === 'list') {
     return (
-      <section className='mx-auto max-w-4xl p-6'>
+      <section className='mx-auto max-w-6xl p-6'>
         <header className='mb-6 flex items-center justify-between'>
           <h1 className='text-base-content flex items-center gap-2 text-2xl font-bold'>
             <ListChecks size={24} className='text-primary' />
@@ -207,7 +231,13 @@ export const CheckTypeContainer = () => {
         )}
         {remainingSuggestions.length > 0 && hasCheckTypes && <hr className='divider my-4' />}
         {hasCheckTypes && (
-          <CheckTypeList checkTypes={checkTypes} onEdit={onEdit} onDelete={onDelete} />
+          <CheckTypeList
+            checkTypes={checkTypes}
+            onEdit={onEdit}
+            onDelete={onDelete}
+            statuses={statusesMap}
+            onLog={setLoggingCheckType}
+          />
         )}
         {!hasCheckTypes && (
           <section className='flex flex-col items-center gap-3 py-16 text-center'>
@@ -223,6 +253,14 @@ export const CheckTypeContainer = () => {
             checkTypeName={deletingCheckType.name}
             onConfirm={handleDeleteConfirm}
             onCancel={() => setDeletingCheckType(null)}
+          />
+        )}
+        {successMessage && <p className='alert alert-success'>{successMessage}</p>}
+        {loggingCheckType && (
+          <LogCheckDialog
+            checkTypeName={loggingCheckType.name}
+            onSubmit={handleLogSubmit}
+            onCancel={() => setLoggingCheckType(null)}
           />
         )}
       </section>

--- a/apps/web/src/features/check-types/components/CheckTypeContainer.tsx
+++ b/apps/web/src/features/check-types/components/CheckTypeContainer.tsx
@@ -1,6 +1,6 @@
 import { zodResolver } from '@hookform/resolvers/zod'
 import { ClipboardPlus, ListChecks, PencilLine, PlusCircle } from 'lucide-react'
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useForm } from 'react-hook-form'
 
 import { Button, FormWrapper } from '~/components/ui'
@@ -29,6 +29,7 @@ export const CheckTypeContainer = () => {
   const [deletingCheckType, setDeletingCheckType] = useState<CheckType | null>(null)
   const [loggingCheckType, setLoggingCheckType] = useState<CheckType | null>(null)
   const [successMessage, setSuccessMessage] = useState<string | null>(null)
+  const successTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const { vehicle, fetchVehicle, hasVehicle } = useVehicle()
   const {
     checkTypes,
@@ -78,6 +79,13 @@ export const CheckTypeContainer = () => {
     }
   }, [mode, hasFetchedVehicle, hasVehicle, vehicle, isCheckTypesLoading])
 
+  useEffect(
+    () => () => {
+      if (successTimeoutRef.current) clearTimeout(successTimeoutRef.current)
+    },
+    []
+  )
+
   const handleSubmit = form.handleSubmit(async values => {
     setServerError(null)
 
@@ -108,7 +116,8 @@ export const CheckTypeContainer = () => {
       await createLog(vehicle.id, loggingCheckType.id, data)
       setLoggingCheckType(null)
       setSuccessMessage('Contrôle enregistré avec succès')
-      setTimeout(() => setSuccessMessage(null), 3000)
+      if (successTimeoutRef.current) clearTimeout(successTimeoutRef.current)
+      successTimeoutRef.current = setTimeout(() => setSuccessMessage(null), 3000)
     } catch (error) {
       setServerError(error instanceof Error ? error.message : 'Une erreur est survenue')
     }
@@ -226,6 +235,11 @@ export const CheckTypeContainer = () => {
           </h1>
           <Button onClick={() => setMode('create')}>Ajouter un contrôle</Button>
         </header>
+        {serverError && (
+          <p className='alert alert-error mb-4' role='alert'>
+            {serverError}
+          </p>
+        )}
         {remainingSuggestions.length > 0 && (
           <SuggestedCheckTypes suggestions={remainingSuggestions} onAdd={onAddSuggestion} />
         )}
@@ -255,7 +269,11 @@ export const CheckTypeContainer = () => {
             onCancel={() => setDeletingCheckType(null)}
           />
         )}
-        {successMessage && <p className='alert alert-success'>{successMessage}</p>}
+        {successMessage && (
+          <p className='alert alert-success' role='status'>
+            {successMessage}
+          </p>
+        )}
         {loggingCheckType && (
           <LogCheckDialog
             checkTypeName={loggingCheckType.name}

--- a/apps/web/src/features/check-types/components/CheckTypeList.spec.tsx
+++ b/apps/web/src/features/check-types/components/CheckTypeList.spec.tsx
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, mock } from 'bun:test'
 
+import type { CheckStatus } from '~/features/check-logs/types'
 import { cleanup, fireEvent, render, screen } from '~/test-utils'
 
 import type { CheckType } from '../types'
@@ -74,5 +75,54 @@ describe('CheckTypeList', () => {
       fireEvent.click(button)
       expect(onDelete).toHaveBeenCalledWith(mockCheckTypes[index])
     })
+  })
+
+  it('should forward statuses to cards as CheckStatusBadge', () => {
+    const actions = mock(() => {})
+    const statuses = new Map<string, CheckStatus>([
+      ['ct-1', 'on-time'],
+      ['ct-2', 'overdue']
+    ])
+
+    render(
+      <CheckTypeList
+        checkTypes={mockCheckTypes}
+        onEdit={actions}
+        onDelete={actions}
+        statuses={statuses}
+      />
+    )
+
+    expect(screen.getByText(/à jour/i)).toBeInTheDocument()
+    expect(screen.getByText(/en retard/i)).toBeInTheDocument()
+  })
+
+  it('should not render badges when statuses is not provided', () => {
+    const actions = mock(() => {})
+
+    render(<CheckTypeList checkTypes={mockCheckTypes} onEdit={actions} onDelete={actions} />)
+
+    expect(screen.queryByText(/à jour/i)).toBeNull()
+    expect(screen.queryByText(/en retard/i)).toBeNull()
+  })
+
+  it('should forward onLog to cards', () => {
+    const actions = mock(() => {})
+    const onLog = mock(() => {})
+
+    render(
+      <CheckTypeList
+        checkTypes={mockCheckTypes}
+        onEdit={actions}
+        onDelete={actions}
+        onLog={onLog}
+      />
+    )
+
+    const logButtons = screen.getAllByRole('button', { name: /journaliser/i })
+
+    expect(logButtons).toHaveLength(2)
+    fireEvent.click(logButtons[0])
+    expect(onLog).toHaveBeenCalledWith(mockCheckTypes[0])
   })
 })

--- a/apps/web/src/features/check-types/components/CheckTypeList.tsx
+++ b/apps/web/src/features/check-types/components/CheckTypeList.tsx
@@ -1,3 +1,5 @@
+import type { CheckStatus } from '~/features/check-logs/types'
+
 import type { CheckType } from '../types'
 
 import { CheckTypeCard } from './CheckTypeCard'
@@ -6,12 +8,27 @@ export interface CheckTypeListProps {
   checkTypes: CheckType[]
   onEdit: (checkType: CheckType) => void
   onDelete: (checkType: CheckType) => void
+  statuses?: Map<string, CheckStatus>
+  onLog?: (checkType: CheckType) => void
 }
 
-export const CheckTypeList = ({ checkTypes, onEdit, onDelete }: CheckTypeListProps) => (
+export const CheckTypeList = ({
+  checkTypes,
+  onEdit,
+  onDelete,
+  statuses,
+  onLog
+}: CheckTypeListProps) => (
   <section className='grid grid-cols-1 gap-5 md:grid-cols-2 lg:grid-cols-3'>
     {checkTypes.map(checkType => (
-      <CheckTypeCard key={checkType.id} checkType={checkType} onEdit={onEdit} onDelete={onDelete} />
+      <CheckTypeCard
+        key={checkType.id}
+        checkType={checkType}
+        onEdit={onEdit}
+        onDelete={onDelete}
+        status={statuses?.get(checkType.id)}
+        onLog={onLog}
+      />
     ))}
   </section>
 )

--- a/apps/web/src/layouts/Main.astro
+++ b/apps/web/src/layouts/Main.astro
@@ -51,6 +51,9 @@ const { user } = Astro.locals
                 <li>
                   <a href='/check-types'>Contrôles</a>
                 </li>
+                <li>
+                  <a href='/check-logs'>Historique</a>
+                </li>
                 {user.role === 'admin' && (
                   <li>
                     <a href='/admin'>Admin</a>
@@ -92,6 +95,9 @@ const { user } = Astro.locals
                     </li>
                     <li>
                       <a href='/check-types'>Contrôles</a>
+                    </li>
+                    <li>
+                      <a href='/check-logs'>Historique</a>
                     </li>
                     {user.role === 'admin' && (
                       <li>

--- a/apps/web/src/pages/check-logs/index.astro
+++ b/apps/web/src/pages/check-logs/index.astro
@@ -1,0 +1,16 @@
+---
+import { CheckLogContainer } from '~/features/check-logs'
+import Main from '~/layouts/Main.astro'
+
+const { user } = Astro.locals
+
+if (!user) {
+  return Astro.redirect('/auth')
+}
+---
+
+<Main title='Historique'>
+  <section class='container mx-auto px-4 py-8'>
+    <CheckLogContainer client:only='react' />
+  </section>
+</Main>

--- a/apps/web/src/pages/profile/index.astro
+++ b/apps/web/src/pages/profile/index.astro
@@ -23,7 +23,7 @@ const userData = user as User
         <a href='/profile/sessions' class='link link-primary text-sm'>Manage Sessions</a>
       </nav>
     </header>
-    <div class='mx-auto flex max-w-xl flex-col gap-8'>
+    <div class='mx-auto flex max-w-2xl flex-col gap-8'>
       <EditProfileContainer client:load userData={userData} />
       <ChangePasswordForm client:load />
       <DeleteAccountSection client:load />

--- a/apps/web/src/pages/profile/sessions.astro
+++ b/apps/web/src/pages/profile/sessions.astro
@@ -15,7 +15,7 @@ if (!user) {
       <h1 class='text-base-content text-4xl font-bold tracking-tight'>Active Sessions</h1>
       <p class='text-base-content/70 mt-2 text-sm'>Manage your active sessions and devices</p>
     </header>
-    <div class='mx-auto flex max-w-xl flex-col gap-8'>
+    <div class='mx-auto flex max-w-2xl flex-col gap-8'>
       <SessionList client:load />
     </div>
   </section>

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -76,12 +76,12 @@
 
 #### Phase 8: Integration & Enhancement
 
-- [ ] Enhanced CheckTypeCard (status badge + "Enregistrer" button) + updated tests
-- [ ] Enhanced CheckTypeList (forward status + onLog props) + updated tests
-- [ ] Enhanced CheckTypeContainer (status fetching + log modal + success feedback) + updated tests
-- [ ] Astro page: /check-logs
-- [ ] Navigation link: "Historique" in Main.astro
-- [ ] Feature barrel exports
+- [x] Enhanced CheckTypeCard (status badge + "Enregistrer" button) + updated tests
+- [x] Enhanced CheckTypeList (forward status + onLog props) + updated tests
+- [x] Enhanced CheckTypeContainer (status fetching + log modal + success feedback) + updated tests
+- [x] Astro page: /check-logs
+- [x] Navigation link: "Historique" in Main.astro
+- [x] Feature barrel exports
 
 ---
 


### PR DESCRIPTION
## Summary

- Integrate check-log status badges and logging into CheckType cards (icon-only edit/delete buttons)
- Wire useCheckLogs + LogCheckDialog into CheckTypeContainer with success feedback
- Add /check-logs Astro page with Historique nav link
- Feature barrel exports for check-logs module
- Badge-info for "never" status visibility
- Layout consistency: max-w-6xl for grids, max-w-2xl for forms/profile, semantic HTML

## Block 4 of 4 — Feature 04: Check Logging COMPLETE

This PR completes Feature 04. All 75 steps across 8 phases and 4 blocks are done.

## Test plan

- [x] All 1,059 tests pass (432 api + 627 web)
- [x] 5 new CheckTypeCard tests (badge, log button, icon buttons)
- [x] 3 new CheckTypeList tests (status forwarding, onLog)
- [x] 4 new CheckTypeContainer integration tests (badges, log dialog, success)
- [x] Status badges visible on check type cards
- [x] Journaliser button opens log dialog from check type card
- [x] Success message after logging a check
- [x] /check-logs page accessible via Historique nav link
- [x] Filter works on history page
- [x] Delete works with confirmation dialog
- [x] Layout consistent across all pages
- [x] Typecheck, lint, format all pass