### PR TITLE
refactor(web): extract DialogShell shared component

### DIFF
--- a/apps/web/src/components/ui/ConfirmDialog.tsx
+++ b/apps/web/src/components/ui/ConfirmDialog.tsx
@@ -1,6 +1,5 @@
-import * as Dialog from '@radix-ui/react-dialog'
-
 import { Button } from './Button'
+import { DialogShell } from './DialogShell'
 
 export interface ConfirmDialogProps {
   title: string
@@ -19,31 +18,14 @@ export const ConfirmDialog = ({
   onConfirm,
   onCancel
 }: ConfirmDialogProps) => (
-  <Dialog.Root
-    open={true}
-    onOpenChange={open => {
-      if (!open) onCancel()
-    }}
-  >
-    <Dialog.Portal>
-      <Dialog.Overlay className='bg-neutral/50 fixed inset-0' onClick={onCancel} />
-      <Dialog.Content
-        className='modal modal-open'
-        onInteractOutside={event => event.preventDefault()}
-      >
-        <div className='modal-box'>
-          <Dialog.Title className='text-lg font-bold'>{title}</Dialog.Title>
-          <Dialog.Description className='py-4'>{message}</Dialog.Description>
-          <div className='modal-action'>
-            <Button variant='outline' onClick={onCancel}>
-              {cancelLabel}
-            </Button>
-            <Button variant='destructive' onClick={onConfirm}>
-              {confirmLabel}
-            </Button>
-          </div>
-        </div>
-      </Dialog.Content>
-    </Dialog.Portal>
-  </Dialog.Root>
+  <DialogShell title={title} onClose={onCancel} description={message}>
+    <div className='modal-action'>
+      <Button variant='outline' onClick={onCancel}>
+        {cancelLabel}
+      </Button>
+      <Button variant='destructive' onClick={onConfirm}>
+        {confirmLabel}
+      </Button>
+    </div>
+  </DialogShell>
 )

--- a/apps/web/src/components/ui/DialogShell.spec.tsx
+++ b/apps/web/src/components/ui/DialogShell.spec.tsx
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, mock } from 'bun:test'
+
+import { cleanup, fireEvent, render, screen } from '~/test-utils'
+
+import { DialogShell } from './DialogShell'
+
+describe('DialogShell', () => {
+  beforeEach(() => {
+    cleanup()
+    document.body.innerHTML = ''
+  })
+
+  it('should render the title', () => {
+    render(
+      <DialogShell title='Test Title' onClose={() => {}}>
+        <p>Content</p>
+      </DialogShell>
+    )
+
+    expect(screen.getByText('Test Title')).toBeInTheDocument()
+  })
+
+  it('should render children', () => {
+    render(
+      <DialogShell title='Test' onClose={() => {}}>
+        <p>Child content</p>
+      </DialogShell>
+    )
+
+    expect(screen.getByText('Child content')).toBeInTheDocument()
+  })
+
+  it('should render description when provided', () => {
+    render(
+      <DialogShell title='Test' onClose={() => {}} description='A description'>
+        <p>Content</p>
+      </DialogShell>
+    )
+
+    expect(screen.getByText('A description')).toBeInTheDocument()
+  })
+
+  it('should not render description when not provided', () => {
+    render(
+      <DialogShell title='Test' onClose={() => {}}>
+        <p>Content</p>
+      </DialogShell>
+    )
+
+    expect(screen.queryByText('A description')).toBeNull()
+  })
+
+  it('should call onClose when backdrop is clicked', () => {
+    const onClose = mock(() => {})
+
+    render(
+      <DialogShell title='Test' onClose={onClose}>
+        <p>Content</p>
+      </DialogShell>
+    )
+
+    const overlay = document.querySelector('.fixed.inset-0')
+    fireEvent.click(overlay!)
+
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('should call onClose when Escape key is pressed', () => {
+    const onClose = mock(() => {})
+
+    render(
+      <DialogShell title='Test' onClose={onClose}>
+        <p>Content</p>
+      </DialogShell>
+    )
+
+    fireEvent.keyDown(screen.getByRole('dialog'), { key: 'Escape' })
+
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('should use DaisyUI modal classes', () => {
+    render(
+      <DialogShell title='Test' onClose={() => {}}>
+        <p>Content</p>
+      </DialogShell>
+    )
+
+    const dialog = screen.getByRole('dialog')
+
+    expect(dialog).toHaveClass('modal')
+    expect(dialog).toHaveClass('modal-open')
+    expect(dialog.querySelector('.modal-box')).toBeInTheDocument()
+  })
+})

--- a/apps/web/src/components/ui/DialogShell.spec.tsx
+++ b/apps/web/src/components/ui/DialogShell.spec.tsx
@@ -47,7 +47,9 @@ describe('DialogShell', () => {
       </DialogShell>
     )
 
-    expect(screen.queryByText('A description')).toBeNull()
+    const dialog = screen.getByRole('dialog')
+
+    expect(dialog).not.toHaveAttribute('aria-describedby')
   })
 
   it('should call onClose when backdrop is clicked', () => {

--- a/apps/web/src/components/ui/DialogShell.tsx
+++ b/apps/web/src/components/ui/DialogShell.tsx
@@ -1,0 +1,33 @@
+import * as Dialog from '@radix-ui/react-dialog'
+import type { ReactNode } from 'react'
+
+export interface DialogShellProps {
+  title: string
+  onClose: () => void
+  children: ReactNode
+  description?: string
+}
+
+export const DialogShell = ({ title, onClose, children, description }: DialogShellProps) => (
+  <Dialog.Root
+    open={true}
+    onOpenChange={open => {
+      if (!open) onClose()
+    }}
+  >
+    <Dialog.Portal>
+      <Dialog.Overlay className='bg-neutral/50 fixed inset-0' onClick={onClose} />
+      <Dialog.Content
+        className='modal modal-open'
+        onInteractOutside={event => event.preventDefault()}
+        {...(!description && { 'aria-describedby': undefined })}
+      >
+        <div className='modal-box'>
+          <Dialog.Title className='mb-4 text-lg font-bold'>{title}</Dialog.Title>
+          {description && <Dialog.Description className='py-4'>{description}</Dialog.Description>}
+          {children}
+        </div>
+      </Dialog.Content>
+    </Dialog.Portal>
+  </Dialog.Root>
+)

--- a/apps/web/src/components/ui/index.ts
+++ b/apps/web/src/components/ui/index.ts
@@ -1,6 +1,8 @@
 export { Button } from './Button'
 export { ConfirmDialog } from './ConfirmDialog'
 export type { ConfirmDialogProps } from './ConfirmDialog'
+export { DialogShell } from './DialogShell'
+export type { DialogShellProps } from './DialogShell'
 export { FormWrapper } from './FormWrapper'
 export { Input } from './Input'
 export { Label } from './Label'

--- a/apps/web/src/features/check-logs/components/LogCheckDialog.tsx
+++ b/apps/web/src/features/check-logs/components/LogCheckDialog.tsx
@@ -1,8 +1,7 @@
 import { zodResolver } from '@hookform/resolvers/zod'
-import * as Dialog from '@radix-ui/react-dialog'
 import { useForm } from 'react-hook-form'
 
-import { Button, FormWrapper } from '~/components/ui'
+import { Button, DialogShell, FormWrapper } from '~/components/ui'
 
 import type { CreateCheckLogSchema } from '../schemas'
 import { createCheckLogSchema } from '../schemas'
@@ -26,30 +25,16 @@ export const LogCheckDialog = ({ checkTypeName, onSubmit, onCancel }: LogCheckDi
   })
 
   return (
-    <Dialog.Root open={true} onOpenChange={onCancel}>
-      <Dialog.Portal>
-        <Dialog.Overlay className='bg-neutral/50 fixed inset-0' onClick={onCancel} />
-        <Dialog.Content
-          className='modal modal-open'
-          onInteractOutside={event => event.preventDefault()}
-          aria-describedby={undefined}
-        >
-          <div className='modal-box'>
-            <Dialog.Title className='mb-4 text-lg font-bold'>
-              Enregistrer un contrôle: {checkTypeName}
-            </Dialog.Title>
-            <FormWrapper onSubmit={form.handleSubmit(onSubmit)} className='grid gap-4'>
-              <LogCheckForm form={form} />
-              <div className='modal-action'>
-                <Button variant='outline' type='button' onClick={onCancel}>
-                  Annuler
-                </Button>
-                <Button type='submit'>Enregistrer</Button>
-              </div>
-            </FormWrapper>
-          </div>
-        </Dialog.Content>
-      </Dialog.Portal>
-    </Dialog.Root>
+    <DialogShell title={`Enregistrer un contrôle: ${checkTypeName}`} onClose={onCancel}>
+      <FormWrapper onSubmit={form.handleSubmit(onSubmit)} className='grid gap-4'>
+        <LogCheckForm form={form} />
+        <div className='modal-action'>
+          <Button variant='outline' type='button' onClick={onCancel}>
+            Annuler
+          </Button>
+          <Button type='submit'>Enregistrer</Button>
+        </div>
+      </FormWrapper>
+    </DialogShell>
   )
 }

--- a/apps/web/src/features/check-types/components/CheckTypeContainer.tsx
+++ b/apps/web/src/features/check-types/components/CheckTypeContainer.tsx
@@ -240,6 +240,11 @@ export const CheckTypeContainer = () => {
             {serverError}
           </p>
         )}
+        {successMessage && (
+          <p className='alert alert-success mb-4' role='status'>
+            {successMessage}
+          </p>
+        )}
         {remainingSuggestions.length > 0 && (
           <SuggestedCheckTypes suggestions={remainingSuggestions} onAdd={onAddSuggestion} />
         )}
@@ -268,11 +273,6 @@ export const CheckTypeContainer = () => {
             onConfirm={handleDeleteConfirm}
             onCancel={() => setDeletingCheckType(null)}
           />
-        )}
-        {successMessage && (
-          <p className='alert alert-success' role='status'>
-            {successMessage}
-          </p>
         )}
         {loggingCheckType && (
           <LogCheckDialog


### PR DESCRIPTION
## Summary

- Extract `DialogShell` reusable component from duplicated Radix Dialog boilerplate
- Refactor `ConfirmDialog` and `LogCheckDialog` to use `DialogShell`
- Move success alert from bottom of card list to top (below header)
- 7 new tests for DialogShell

## Post-Feature Refactoring — Feature 04: Check Logging

Reduces ~15 lines of Radix boilerplate per dialog to a single `<DialogShell>` wrapper.

## Test plan

- [x] All 634 web tests pass
- [x] ConfirmDialog tests still pass (refactored internals)
- [x] LogCheckDialog tests still pass (refactored internals)
- [x] 7 new DialogShell tests
- [x] Typecheck, lint, format all pass