### PR TITLE
feature(admin): add onboarding flows — create, verify, reset password

### DIFF
--- a/apps/web/src/features/admin/components/CreateUserDialog.spec.tsx
+++ b/apps/web/src/features/admin/components/CreateUserDialog.spec.tsx
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it, mock } from 'bun:test'
+
+import { cleanup, fireEvent, render, screen, userEvent, waitFor } from '~/test-utils'
+
+import { CreateUserDialog } from './CreateUserDialog'
+
+const renderDialog = async (props: Partial<Parameters<typeof CreateUserDialog>[0]> = {}) => {
+  const result = render(
+    <CreateUserDialog
+      onCancel={props.onCancel ?? (() => {})}
+      onSubmit={props.onSubmit ?? (async () => {})}
+    />
+  )
+
+  await waitFor(() => {
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+  })
+
+  return result
+}
+
+describe('CreateUserDialog', () => {
+  beforeEach(() => {
+    cleanup()
+    document.body.innerHTML = ''
+  })
+
+  it('renders the dialog title', async () => {
+    await renderDialog()
+
+    expect(screen.getByText(/ajouter un user/i)).toBeInTheDocument()
+  })
+
+  it('renders all five fields', async () => {
+    await renderDialog()
+
+    expect(screen.getByLabelText(/username/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/email/i)).toBeInTheDocument()
+    expect(screen.getByLabelText('Password')).toBeInTheDocument()
+    expect(screen.getByLabelText(/first name/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/last name/i)).toBeInTheDocument()
+  })
+
+  it('calls onCancel when cancel clicked', async () => {
+    const onCancel = mock(() => {})
+    await renderDialog({ onCancel })
+
+    fireEvent.click(screen.getByRole('button', { name: /annuler/i }))
+
+    expect(onCancel).toHaveBeenCalledTimes(1)
+  })
+
+  it('submits valid payload via onSubmit', async () => {
+    const onSubmit = mock(async () => {})
+    const user = userEvent.setup()
+    await renderDialog({ onSubmit })
+
+    await user.type(screen.getByLabelText(/username/i), 'newtester')
+    await user.type(screen.getByLabelText(/email/i), 'tester@example.com')
+    await user.type(screen.getByLabelText('Password'), 'secret123')
+    await user.click(screen.getByRole('button', { name: /créer/i }))
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledTimes(1)
+    })
+
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        username: 'newtester',
+        email: 'tester@example.com',
+        password: 'secret123'
+      })
+    )
+  })
+
+  it('shows an inline server error when onSubmit throws', async () => {
+    const onSubmit = mock(async () => {
+      throw new Error('Email already in use')
+    })
+    const user = userEvent.setup()
+    await renderDialog({ onSubmit })
+
+    await user.type(screen.getByLabelText(/username/i), 'newtester')
+    await user.type(screen.getByLabelText(/email/i), 'tester@example.com')
+    await user.type(screen.getByLabelText('Password'), 'secret123')
+    await user.click(screen.getByRole('button', { name: /créer/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText(/email already in use/i)).toBeInTheDocument()
+    })
+  })
+})

--- a/apps/web/src/features/admin/components/CreateUserDialog.tsx
+++ b/apps/web/src/features/admin/components/CreateUserDialog.tsx
@@ -1,0 +1,56 @@
+import { zodResolver } from '@hookform/resolvers/zod'
+import { useState } from 'react'
+import { useForm } from 'react-hook-form'
+
+import { Button, DialogShell, FormWrapper } from '~/components/ui'
+
+import type { CreateUserSchema } from '../schemas'
+import { createUserSchema } from '../schemas'
+
+import { CreateUserForm } from './CreateUserForm'
+
+export interface CreateUserDialogProps {
+  onCancel: () => void
+  onSubmit: (values: CreateUserSchema) => Promise<void>
+}
+
+export const CreateUserDialog = ({ onCancel, onSubmit }: CreateUserDialogProps) => {
+  const [serverError, setServerError] = useState<string | null>(null)
+
+  const form = useForm<CreateUserSchema>({
+    resolver: zodResolver(createUserSchema),
+    defaultValues: { username: '', email: '', password: '', firstName: '', lastName: '' },
+    mode: 'onTouched'
+  })
+
+  const handleSubmit = form.handleSubmit(async values => {
+    setServerError(null)
+
+    try {
+      await onSubmit(values)
+    } catch (error) {
+      setServerError(error instanceof Error ? error.message : 'Failed to create user')
+    }
+  })
+
+  return (
+    <DialogShell title='Ajouter un user' onClose={onCancel}>
+      <FormWrapper onSubmit={handleSubmit} error={serverError} className='grid gap-4'>
+        <CreateUserForm form={form} />
+        <div className='modal-action'>
+          <Button
+            variant='outline'
+            type='button'
+            onClick={onCancel}
+            disabled={form.formState.isSubmitting}
+          >
+            Annuler
+          </Button>
+          <Button type='submit' disabled={form.formState.isSubmitting}>
+            {form.formState.isSubmitting ? 'Création...' : 'Créer'}
+          </Button>
+        </div>
+      </FormWrapper>
+    </DialogShell>
+  )
+}

--- a/apps/web/src/features/admin/components/CreateUserForm.spec.tsx
+++ b/apps/web/src/features/admin/components/CreateUserForm.spec.tsx
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'bun:test'
+import { useForm } from 'react-hook-form'
+
+import { cleanup, render, screen } from '~/test-utils'
+
+import type { CreateUserSchema } from '../schemas'
+
+import { CreateUserForm } from './CreateUserForm'
+
+const Harness = () => {
+  const form = useForm<CreateUserSchema>({
+    defaultValues: { username: '', email: '', password: '', firstName: '', lastName: '' }
+  })
+
+  return <CreateUserForm form={form} />
+}
+
+describe('CreateUserForm', () => {
+  it('renders all five fields', () => {
+    cleanup()
+    render(<Harness />)
+
+    expect(screen.getByLabelText(/username/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/email/i)).toBeInTheDocument()
+    expect(screen.getByLabelText('Password')).toBeInTheDocument()
+    expect(screen.getByLabelText(/first name/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/last name/i)).toBeInTheDocument()
+  })
+
+  it('renders password as type=text (admin reads what they type)', () => {
+    cleanup()
+    render(<Harness />)
+
+    expect(screen.getByLabelText('Password')).toHaveAttribute('type', 'text')
+  })
+})

--- a/apps/web/src/features/admin/components/CreateUserForm.tsx
+++ b/apps/web/src/features/admin/components/CreateUserForm.tsx
@@ -1,0 +1,55 @@
+import type { UseFormReturn } from 'react-hook-form'
+
+import { Input } from '~/components/ui'
+
+import type { CreateUserSchema } from '../schemas'
+
+export interface CreateUserFormProps {
+  form: UseFormReturn<CreateUserSchema>
+}
+
+export const CreateUserForm = ({ form }: CreateUserFormProps) => (
+  <>
+    <Input
+      {...form.register('username')}
+      label='Username'
+      placeholder='Ex: newtester'
+      error={form.formState.errors.username?.message}
+      autoComplete='off'
+    />
+
+    <Input
+      {...form.register('email')}
+      type='email'
+      label='Email'
+      placeholder='Ex: tester@example.com'
+      error={form.formState.errors.email?.message}
+      autoComplete='off'
+    />
+
+    <Input
+      {...form.register('password')}
+      type='text'
+      label='Password'
+      placeholder='Ex: Secret123!'
+      error={form.formState.errors.password?.message}
+      autoComplete='off'
+    />
+
+    <Input
+      {...form.register('firstName')}
+      label='First name (optional)'
+      placeholder='Ex: Alex'
+      error={form.formState.errors.firstName?.message}
+      autoComplete='off'
+    />
+
+    <Input
+      {...form.register('lastName')}
+      label='Last name (optional)'
+      placeholder='Ex: Dupont'
+      error={form.formState.errors.lastName?.message}
+      autoComplete='off'
+    />
+  </>
+)

--- a/apps/web/src/features/admin/components/ResetPasswordDialog.spec.tsx
+++ b/apps/web/src/features/admin/components/ResetPasswordDialog.spec.tsx
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, mock } from 'bun:test'
+
+import { cleanup, fireEvent, render, screen, userEvent, waitFor } from '~/test-utils'
+
+import { ResetPasswordDialog } from './ResetPasswordDialog'
+
+const renderDialog = async (props: Partial<Parameters<typeof ResetPasswordDialog>[0]> = {}) => {
+  const result = render(
+    <ResetPasswordDialog
+      username={props.username ?? 'testuser'}
+      onCancel={props.onCancel ?? (() => {})}
+      onSubmit={props.onSubmit ?? (async () => {})}
+    />
+  )
+
+  await waitFor(() => {
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+  })
+
+  return result
+}
+
+describe('ResetPasswordDialog', () => {
+  beforeEach(() => {
+    cleanup()
+    document.body.innerHTML = ''
+  })
+
+  it('renders the title and out-of-band warning', async () => {
+    await renderDialog({ username: 'alice' })
+
+    expect(screen.getByText(/réinitialiser le password/i)).toBeInTheDocument()
+    expect(screen.getByText(/alice/i)).toBeInTheDocument()
+    expect(screen.getByText(/transmettez-le vous-même/i)).toBeInTheDocument()
+  })
+
+  it('calls onCancel when cancel clicked', async () => {
+    const onCancel = mock(() => {})
+    await renderDialog({ onCancel })
+
+    fireEvent.click(screen.getByRole('button', { name: /annuler/i }))
+
+    expect(onCancel).toHaveBeenCalledTimes(1)
+  })
+
+  it('submits a valid payload via onSubmit', async () => {
+    const onSubmit = mock(async () => {})
+    const user = userEvent.setup()
+    await renderDialog({ onSubmit })
+
+    await user.type(screen.getByLabelText(/nouveau password/i), 'newsecret123')
+    await user.click(screen.getByRole('button', { name: /enregistrer/i }))
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith({ password: 'newsecret123' })
+    })
+  })
+
+  it('shows an inline error when onSubmit throws', async () => {
+    const onSubmit = mock(async () => {
+      throw new Error('Password policy failure')
+    })
+    const user = userEvent.setup()
+    await renderDialog({ onSubmit })
+
+    await user.type(screen.getByLabelText(/nouveau password/i), 'newsecret123')
+    await user.click(screen.getByRole('button', { name: /enregistrer/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText(/password policy failure/i)).toBeInTheDocument()
+    })
+  })
+})

--- a/apps/web/src/features/admin/components/ResetPasswordDialog.tsx
+++ b/apps/web/src/features/admin/components/ResetPasswordDialog.tsx
@@ -1,0 +1,59 @@
+import { zodResolver } from '@hookform/resolvers/zod'
+import { useState } from 'react'
+import { useForm } from 'react-hook-form'
+
+import { Button, DialogShell, FormWrapper } from '~/components/ui'
+
+import type { ResetPasswordSchema } from '../schemas'
+import { resetPasswordSchema } from '../schemas'
+
+import { ResetPasswordForm } from './ResetPasswordForm'
+
+export interface ResetPasswordDialogProps {
+  username: string
+  onCancel: () => void
+  onSubmit: (values: ResetPasswordSchema) => Promise<void>
+}
+
+export const ResetPasswordDialog = ({ username, onCancel, onSubmit }: ResetPasswordDialogProps) => {
+  const [serverError, setServerError] = useState<string | null>(null)
+
+  const form = useForm<ResetPasswordSchema>({
+    resolver: zodResolver(resetPasswordSchema),
+    defaultValues: { password: '' },
+    mode: 'onTouched'
+  })
+
+  const handleSubmit = form.handleSubmit(async values => {
+    setServerError(null)
+
+    try {
+      await onSubmit(values)
+    } catch (error) {
+      setServerError(error instanceof Error ? error.message : 'Failed to reset password')
+    }
+  })
+
+  const description = `Définissez un nouveau password pour ${username}. Le password n'est envoyé à personne — transmettez-le vous-même au testeur.`
+
+  return (
+    <DialogShell title='Réinitialiser le password' description={description} onClose={onCancel}>
+      <FormWrapper onSubmit={handleSubmit} error={serverError} className='grid gap-4'>
+        <ResetPasswordForm form={form} />
+        <div className='modal-action'>
+          <Button
+            variant='outline'
+            type='button'
+            onClick={onCancel}
+            disabled={form.formState.isSubmitting}
+          >
+            Annuler
+          </Button>
+          <Button type='submit' disabled={form.formState.isSubmitting}>
+            {form.formState.isSubmitting ? 'Enregistrement...' : 'Enregistrer'}
+          </Button>
+        </div>
+      </FormWrapper>
+    </DialogShell>
+  )
+}

--- a/apps/web/src/features/admin/components/ResetPasswordForm.spec.tsx
+++ b/apps/web/src/features/admin/components/ResetPasswordForm.spec.tsx
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'bun:test'
+import { useForm } from 'react-hook-form'
+
+import { cleanup, render, screen } from '~/test-utils'
+
+import type { ResetPasswordSchema } from '../schemas'
+
+import { ResetPasswordForm } from './ResetPasswordForm'
+
+const Harness = () => {
+  const form = useForm<ResetPasswordSchema>({ defaultValues: { password: '' } })
+
+  return <ResetPasswordForm form={form} />
+}
+
+describe('ResetPasswordForm', () => {
+  it('renders the password field', () => {
+    cleanup()
+    render(<Harness />)
+
+    expect(screen.getByLabelText(/nouveau password/i)).toBeInTheDocument()
+  })
+
+  it('renders password as type=text', () => {
+    cleanup()
+    render(<Harness />)
+
+    expect(screen.getByLabelText(/nouveau password/i)).toHaveAttribute('type', 'text')
+  })
+})

--- a/apps/web/src/features/admin/components/ResetPasswordForm.tsx
+++ b/apps/web/src/features/admin/components/ResetPasswordForm.tsx
@@ -1,0 +1,20 @@
+import type { UseFormReturn } from 'react-hook-form'
+
+import { Input } from '~/components/ui'
+
+import type { ResetPasswordSchema } from '../schemas'
+
+export interface ResetPasswordFormProps {
+  form: UseFormReturn<ResetPasswordSchema>
+}
+
+export const ResetPasswordForm = ({ form }: ResetPasswordFormProps) => (
+  <Input
+    {...form.register('password')}
+    type='text'
+    label='Nouveau password'
+    placeholder='Ex: NouveauSecret123'
+    error={form.formState.errors.password?.message}
+    autoComplete='off'
+  />
+)

--- a/apps/web/src/features/admin/components/UserList.spec.tsx
+++ b/apps/web/src/features/admin/components/UserList.spec.tsx
@@ -1,7 +1,8 @@
 import { beforeEach, describe, expect, it, mock } from 'bun:test'
 
 import { admin } from '~/lib/authClient'
-import { cleanup, render, screen, waitFor } from '~/test-utils'
+import { act, cleanup, render, screen, userEvent, waitFor } from '~/test-utils'
+import * as navigationUtils from '~/utils/navigation'
 
 import { UserList } from './UserList'
 
@@ -37,23 +38,35 @@ const mockUsers = [
 
 mock.module('~/lib/authClient', () => ({
   admin: {
-    listUsers: mock(() => Promise.resolve({ data: { users: mockUsers }, error: null }))
+    listUsers: mock(() => Promise.resolve({ data: { users: mockUsers }, error: null })),
+    createUser: mock(() => Promise.resolve({ data: { user: { id: 'user-new' } }, error: null }))
   }
+}))
+
+mock.module('~/utils/navigation', () => ({
+  redirect: mock(() => {})
 }))
 
 describe('UserList', () => {
   beforeEach(() => {
     cleanup()
     const mockListUsers = admin.listUsers as unknown as ReturnType<typeof mock>
+    const mockCreateUser = admin.createUser as unknown as ReturnType<typeof mock>
+    const mockRedirect = navigationUtils.redirect as unknown as ReturnType<typeof mock>
     mockListUsers.mockClear()
+    mockCreateUser.mockClear()
+    mockRedirect.mockClear()
     mockListUsers.mockResolvedValue({ data: { users: mockUsers }, error: null })
+    mockCreateUser.mockResolvedValue({ data: { user: { id: 'user-new' } }, error: null })
   })
 
-  it('should show loading state initially', () => {
+  it('should show loading state initially', async () => {
     const mockListUsers = admin.listUsers as unknown as ReturnType<typeof mock>
     mockListUsers.mockReturnValue(new Promise(() => {}))
 
-    render(<UserList />)
+    await act(async () => {
+      render(<UserList />)
+    })
 
     expect(screen.getByText(/loading users/i)).toBeInTheDocument()
   })
@@ -119,6 +132,93 @@ describe('UserList', () => {
 
     await waitFor(() => {
       expect(screen.getByText(/no users found/i)).toBeInTheDocument()
+    })
+  })
+
+  it('renders the page title h1', async () => {
+    render(<UserList />)
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { level: 1, name: /manage users/i })).toBeInTheDocument()
+    })
+  })
+
+  it('renders the "Ajouter un user" button', async () => {
+    render(<UserList />)
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /ajouter un user/i })).toBeInTheDocument()
+    })
+  })
+
+  it('opens the create dialog when "Ajouter un user" is clicked', async () => {
+    const user = userEvent.setup()
+    render(<UserList />)
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /ajouter un user/i })).toBeInTheDocument()
+    })
+
+    await user.click(screen.getByRole('button', { name: /ajouter un user/i }))
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+  })
+
+  it('calls admin.createUser with the correct payload and redirects', async () => {
+    const user = userEvent.setup()
+    render(<UserList />)
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /ajouter un user/i })).toBeInTheDocument()
+    })
+
+    await user.click(screen.getByRole('button', { name: /ajouter un user/i }))
+    await user.type(screen.getByLabelText(/username/i), 'newtester')
+    await user.type(screen.getByLabelText(/email/i), 'tester@example.com')
+    await user.type(screen.getByLabelText('Password'), 'secret123')
+    await user.click(screen.getByRole('button', { name: /créer/i }))
+
+    await waitFor(() => {
+      expect(admin.createUser).toHaveBeenCalledWith({
+        email: 'tester@example.com',
+        password: 'secret123',
+        name: 'newtester',
+        data: {
+          username: 'newtester',
+          firstName: null,
+          lastName: null,
+          emailVerified: true
+        }
+      })
+    })
+
+    await waitFor(() => {
+      expect(navigationUtils.redirect).toHaveBeenCalledWith('/admin/users/user-new')
+    })
+  })
+
+  it('surfaces inline error when createUser fails', async () => {
+    const mockCreateUser = admin.createUser as unknown as ReturnType<typeof mock>
+    mockCreateUser.mockResolvedValueOnce({
+      data: null,
+      error: { message: 'Email already in use' }
+    })
+
+    const user = userEvent.setup()
+    render(<UserList />)
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /ajouter un user/i })).toBeInTheDocument()
+    })
+
+    await user.click(screen.getByRole('button', { name: /ajouter un user/i }))
+    await user.type(screen.getByLabelText(/username/i), 'newtester')
+    await user.type(screen.getByLabelText(/email/i), 'tester@example.com')
+    await user.type(screen.getByLabelText('Password'), 'secret123')
+    await user.click(screen.getByRole('button', { name: /créer/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText(/email already in use/i)).toBeInTheDocument()
     })
   })
 })

--- a/apps/web/src/features/admin/components/UserList.tsx
+++ b/apps/web/src/features/admin/components/UserList.tsx
@@ -1,6 +1,13 @@
+import { UserPlus } from 'lucide-react'
 import { useEffect, useState } from 'react'
 
+import { Button } from '~/components/ui'
 import { admin } from '~/lib/authClient'
+import { redirect } from '~/utils/navigation'
+
+import type { CreateUserSchema } from '../schemas'
+
+import { CreateUserDialog } from './CreateUserDialog'
 
 type AdminUser = {
   id: string
@@ -16,6 +23,7 @@ export const UserList = () => {
   const [isLoading, setIsLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [users, setUsers] = useState<AdminUser[]>([])
+  const [isCreateOpen, setIsCreateOpen] = useState(false)
 
   const fetchUsers = async () => {
     setIsLoading(true)
@@ -37,60 +45,101 @@ export const UserList = () => {
     fetchUsers()
   }, [])
 
-  if (isLoading) {
-    return <p className='text-base-content/70'>Loading users...</p>
+  const handleCreate = async (values: CreateUserSchema): Promise<void> => {
+    const name =
+      [values.firstName, values.lastName].filter(Boolean).join(' ').trim() || values.username
+
+    const result = await admin.createUser({
+      email: values.email,
+      password: values.password,
+      name,
+      data: {
+        username: values.username,
+        firstName: values.firstName || null,
+        lastName: values.lastName || null,
+        emailVerified: true
+      }
+    })
+
+    if (result.error) {
+      throw new Error(result.error.message ?? 'Failed to create user')
+    }
+
+    const newUserId = result.data?.user?.id
+    if (!newUserId) {
+      throw new Error('Failed to retrieve new user ID')
+    }
+
+    setIsCreateOpen(false)
+    redirect(`/admin/users/${newUserId}`)
   }
 
-  if (error) {
-    return <p className='text-error'>{error}</p>
-  }
+  const renderContent = () => {
+    if (isLoading) return <p className='text-base-content/70'>Loading users...</p>
+    if (error) return <p className='text-error'>{error}</p>
+    if (users.length === 0) return <p className='text-base-content/70'>No users found.</p>
 
-  if (users.length === 0) {
-    return <p className='text-base-content/70'>No users found.</p>
+    return (
+      <section className='overflow-x-auto'>
+        <table className='table-zebra table'>
+          <thead>
+            <tr>
+              <th>Username</th>
+              <th>Email</th>
+              <th>Role</th>
+              <th>Status</th>
+              <th>Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {users.map(user => (
+              <tr key={user.id}>
+                <td>{user.username}</td>
+                <td>{user.email}</td>
+                <td>
+                  <span
+                    className={`badge ${user.role === 'admin' ? 'badge-primary' : 'badge-neutral'}`}
+                  >
+                    {user.role}
+                  </span>
+                </td>
+                <td>
+                  {user.banned ? (
+                    <span className='badge badge-error'>Banned</span>
+                  ) : user.emailVerified ? (
+                    <span className='badge badge-success'>Verified</span>
+                  ) : (
+                    <span className='badge badge-warning'>Unverified</span>
+                  )}
+                </td>
+                <td>
+                  <a href={`/admin/users/${user.id}`} className='link link-primary'>
+                    View
+                  </a>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </section>
+    )
   }
 
   return (
-    <section className='overflow-x-auto'>
-      <table className='table-zebra table'>
-        <thead>
-          <tr>
-            <th>Username</th>
-            <th>Email</th>
-            <th>Role</th>
-            <th>Status</th>
-            <th>Actions</th>
-          </tr>
-        </thead>
-        <tbody>
-          {users.map(user => (
-            <tr key={user.id}>
-              <td>{user.username}</td>
-              <td>{user.email}</td>
-              <td>
-                <span
-                  className={`badge ${user.role === 'admin' ? 'badge-primary' : 'badge-neutral'}`}
-                >
-                  {user.role}
-                </span>
-              </td>
-              <td>
-                {user.banned ? (
-                  <span className='badge badge-error'>Banned</span>
-                ) : user.emailVerified ? (
-                  <span className='badge badge-success'>Verified</span>
-                ) : (
-                  <span className='badge badge-warning'>Unverified</span>
-                )}
-              </td>
-              <td>
-                <a href={`/admin/users/${user.id}`} className='link link-primary'>
-                  View
-                </a>
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
+    <section className='flex flex-col gap-6'>
+      <header className='flex flex-col gap-3 md:flex-row md:items-center md:justify-between'>
+        <h1 className='text-base-content text-2xl font-bold'>Manage Users</h1>
+        <Button onClick={() => setIsCreateOpen(true)} className='gap-2'>
+          <UserPlus size={16} />
+          Ajouter un user
+        </Button>
+      </header>
+
+      {renderContent()}
+
+      {isCreateOpen && (
+        <CreateUserDialog onCancel={() => setIsCreateOpen(false)} onSubmit={handleCreate} />
+      )}
     </section>
   )
 }

--- a/apps/web/src/features/admin/components/UserManagement.spec.tsx
+++ b/apps/web/src/features/admin/components/UserManagement.spec.tsx
@@ -23,7 +23,9 @@ mock.module('~/lib/authClient', () => ({
     setRole: mock(() => Promise.resolve({ error: null })),
     banUser: mock(() => Promise.resolve({ error: null })),
     unbanUser: mock(() => Promise.resolve({ error: null })),
-    removeUser: mock(() => Promise.resolve({ error: null }))
+    removeUser: mock(() => Promise.resolve({ error: null })),
+    updateUser: mock(() => Promise.resolve({ error: null })),
+    setUserPassword: mock(() => Promise.resolve({ error: null }))
   }
 }))
 
@@ -38,18 +40,24 @@ describe('UserManagement', () => {
     const mockBanUser = admin.banUser as unknown as ReturnType<typeof mock>
     const mockUnbanUser = admin.unbanUser as unknown as ReturnType<typeof mock>
     const mockRemoveUser = admin.removeUser as unknown as ReturnType<typeof mock>
+    const mockUpdateUser = admin.updateUser as unknown as ReturnType<typeof mock>
+    const mockSetPassword = admin.setUserPassword as unknown as ReturnType<typeof mock>
     const mockRedirect = navigationUtils.redirect as unknown as ReturnType<typeof mock>
 
     mockSetRole.mockClear()
     mockBanUser.mockClear()
     mockUnbanUser.mockClear()
     mockRemoveUser.mockClear()
+    mockUpdateUser.mockClear()
+    mockSetPassword.mockClear()
     mockRedirect.mockClear()
 
     mockSetRole.mockResolvedValue({ error: null })
     mockBanUser.mockResolvedValue({ error: null })
     mockUnbanUser.mockResolvedValue({ error: null })
     mockRemoveUser.mockResolvedValue({ error: null })
+    mockUpdateUser.mockResolvedValue({ error: null })
+    mockSetPassword.mockResolvedValue({ error: null })
   })
 
   it('should display user details', () => {
@@ -145,6 +153,125 @@ describe('UserManagement', () => {
 
     await waitFor(() => {
       expect(screen.getByText(/permission denied/i)).toBeInTheDocument()
+    })
+  })
+
+  it('shows "Valider l\'email" button when user is unverified', () => {
+    const unverified = { ...mockUser, emailVerified: false }
+    render(<UserManagement user={unverified} />)
+
+    expect(screen.getByRole('button', { name: /valider l'email/i })).toBeInTheDocument()
+  })
+
+  it('hides "Valider l\'email" button when user is already verified', () => {
+    render(<UserManagement user={mockUser} />)
+
+    expect(screen.queryByRole('button', { name: /valider l'email/i })).not.toBeInTheDocument()
+  })
+
+  it('renders "Réinitialiser le password" button for any user', () => {
+    render(<UserManagement user={mockUser} />)
+
+    expect(screen.getByRole('button', { name: /réinitialiser le password/i })).toBeInTheDocument()
+  })
+
+  it("calls admin.updateUser with emailVerified: true when Valider l'email clicked", async () => {
+    const unverified = { ...mockUser, emailVerified: false }
+    const user = userEvent.setup()
+    render(<UserManagement user={unverified} />)
+
+    await user.click(screen.getByRole('button', { name: /valider l'email/i }))
+
+    await waitFor(() => {
+      expect(admin.updateUser).toHaveBeenCalledWith({
+        userId: 'user-1',
+        data: { emailVerified: true }
+      })
+    })
+  })
+
+  it('hides the Valider button and flips the badge after success', async () => {
+    const unverified = { ...mockUser, emailVerified: false }
+    const user = userEvent.setup()
+    render(<UserManagement user={unverified} />)
+
+    await user.click(screen.getByRole('button', { name: /valider l'email/i }))
+
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: /valider l'email/i })).not.toBeInTheDocument()
+      expect(screen.getByText('Verified')).toBeInTheDocument()
+    })
+  })
+
+  it('shows an inline success message after verify', async () => {
+    const unverified = { ...mockUser, emailVerified: false }
+    const user = userEvent.setup()
+    render(<UserManagement user={unverified} />)
+
+    await user.click(screen.getByRole('button', { name: /valider l'email/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText(/email validé/i)).toBeInTheDocument()
+    })
+  })
+
+  it('shows an inline error when updateUser fails', async () => {
+    const mockUpdateUser = admin.updateUser as unknown as ReturnType<typeof mock>
+    mockUpdateUser.mockResolvedValueOnce({ error: { message: 'Permission denied' } })
+
+    const unverified = { ...mockUser, emailVerified: false }
+    const user = userEvent.setup()
+    render(<UserManagement user={unverified} />)
+
+    await user.click(screen.getByRole('button', { name: /valider l'email/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText(/permission denied/i)).toBeInTheDocument()
+    })
+  })
+
+  it('opens the reset dialog when Réinitialiser le password clicked', async () => {
+    const user = userEvent.setup()
+    render(<UserManagement user={mockUser} />)
+
+    await user.click(screen.getByRole('button', { name: /réinitialiser le password/i }))
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+  })
+
+  it('calls admin.setUserPassword and shows out-of-band reminder after success', async () => {
+    const user = userEvent.setup()
+    render(<UserManagement user={mockUser} />)
+
+    await user.click(screen.getByRole('button', { name: /réinitialiser le password/i }))
+    await user.type(screen.getByLabelText(/nouveau password/i), 'newsecret123')
+    await user.click(screen.getByRole('button', { name: /enregistrer/i }))
+
+    await waitFor(() => {
+      expect(admin.setUserPassword).toHaveBeenCalledWith({
+        userId: 'user-1',
+        newPassword: 'newsecret123'
+      })
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText(/transmettez-le vous-même/i)).toBeInTheDocument()
+    })
+  })
+
+  it('surfaces inline error when setUserPassword fails', async () => {
+    const mockSetPassword = admin.setUserPassword as unknown as ReturnType<typeof mock>
+    mockSetPassword.mockResolvedValueOnce({ error: { message: 'Password policy failure' } })
+
+    const user = userEvent.setup()
+    render(<UserManagement user={mockUser} />)
+
+    await user.click(screen.getByRole('button', { name: /réinitialiser le password/i }))
+    await user.type(screen.getByLabelText(/nouveau password/i), 'newsecret123')
+    await user.click(screen.getByRole('button', { name: /enregistrer/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText(/password policy failure/i)).toBeInTheDocument()
     })
   })
 })

--- a/apps/web/src/features/admin/components/UserManagement.tsx
+++ b/apps/web/src/features/admin/components/UserManagement.tsx
@@ -1,8 +1,13 @@
+import { Lock, MailCheck } from 'lucide-react'
 import { useState } from 'react'
 
 import { Button } from '~/components/ui'
 import { admin } from '~/lib/authClient'
 import { redirect } from '~/utils/navigation'
+
+import type { ResetPasswordSchema } from '../schemas'
+
+import { ResetPasswordDialog } from './ResetPasswordDialog'
 
 type UserData = {
   id: string
@@ -24,6 +29,28 @@ export const UserManagement = ({ user: initialUser }: Props) => {
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [success, setSuccess] = useState<string | null>(null)
+  const [isResetOpen, setIsResetOpen] = useState(false)
+
+  const handleVerify = async () => {
+    setIsLoading(true)
+    setError(null)
+    setSuccess(null)
+
+    const result = await admin.updateUser({
+      userId: user.id,
+      data: { emailVerified: true }
+    })
+
+    if (result.error) {
+      setError(result.error.message ?? 'Failed to verify email')
+      setIsLoading(false)
+      return
+    }
+
+    setUser({ ...user, emailVerified: true })
+    setSuccess("Email validé — l'utilisateur peut désormais se connecter.")
+    setIsLoading(false)
+  }
 
   const handleSetRole = async (role: 'user' | 'admin') => {
     setIsLoading(true)
@@ -76,6 +103,28 @@ export const UserManagement = ({ user: initialUser }: Props) => {
 
     setUser({ ...user, banned: false })
     setSuccess('User unbanned')
+    setIsLoading(false)
+  }
+
+  const handleResetPassword = async (values: ResetPasswordSchema): Promise<void> => {
+    setIsLoading(true)
+    setError(null)
+    setSuccess(null)
+
+    const result = await admin.setUserPassword({
+      userId: user.id,
+      newPassword: values.password
+    })
+
+    if (result.error) {
+      setIsLoading(false)
+      throw new Error(result.error.message ?? 'Failed to reset password')
+    }
+
+    setIsResetOpen(false)
+    setSuccess(
+      `Password mis à jour pour ${user.username}. Transmettez-le vous-même au testeur — il n'est envoyé à personne.`
+    )
     setIsLoading(false)
   }
 
@@ -169,6 +218,13 @@ export const UserManagement = ({ user: initialUser }: Props) => {
               </Button>
             )}
 
+            {!user.emailVerified && (
+              <Button onClick={handleVerify} disabled={isLoading} className='gap-2'>
+                <MailCheck size={16} />
+                Valider l&apos;email
+              </Button>
+            )}
+
             {user.banned ? (
               <Button variant='outline' onClick={handleUnban} disabled={isLoading}>
                 Unban User
@@ -179,12 +235,30 @@ export const UserManagement = ({ user: initialUser }: Props) => {
               </Button>
             )}
 
+            <Button
+              variant='outline'
+              onClick={() => setIsResetOpen(true)}
+              disabled={isLoading}
+              className='gap-2'
+            >
+              <Lock size={16} />
+              Réinitialiser le password
+            </Button>
+
             <Button variant='destructive' onClick={handleDelete} disabled={isLoading}>
               Delete User
             </Button>
           </div>
         </div>
       </article>
+
+      {isResetOpen && (
+        <ResetPasswordDialog
+          username={user.username}
+          onCancel={() => setIsResetOpen(false)}
+          onSubmit={handleResetPassword}
+        />
+      )}
     </section>
   )
 }

--- a/apps/web/src/features/admin/schemas/createUser.schema.spec.ts
+++ b/apps/web/src/features/admin/schemas/createUser.schema.spec.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'bun:test'
+
+import { createUserSchema } from './createUser.schema'
+
+describe('createUserSchema', () => {
+  it('validates a complete payload', () => {
+    const result = createUserSchema.safeParse({
+      username: 'newtester',
+      email: 'tester@example.com',
+      password: 'secret123',
+      firstName: 'New',
+      lastName: 'Tester'
+    })
+
+    expect(result.success).toBe(true)
+  })
+
+  it('validates a minimal payload (no firstName / lastName)', () => {
+    const result = createUserSchema.safeParse({
+      username: 'newtester',
+      email: 'tester@example.com',
+      password: 'secret123'
+    })
+
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects a username shorter than 3 chars', () => {
+    const result = createUserSchema.safeParse({
+      username: 'ab',
+      email: 'tester@example.com',
+      password: 'secret123'
+    })
+
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects a username with disallowed characters', () => {
+    const result = createUserSchema.safeParse({
+      username: 'bad name!',
+      email: 'tester@example.com',
+      password: 'secret123'
+    })
+
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects an invalid email', () => {
+    const result = createUserSchema.safeParse({
+      username: 'newtester',
+      email: 'not-an-email',
+      password: 'secret123'
+    })
+
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects a password shorter than 8 chars', () => {
+    const result = createUserSchema.safeParse({
+      username: 'newtester',
+      email: 'tester@example.com',
+      password: 'short'
+    })
+
+    expect(result.success).toBe(false)
+  })
+})

--- a/apps/web/src/features/admin/schemas/createUser.schema.ts
+++ b/apps/web/src/features/admin/schemas/createUser.schema.ts
@@ -1,0 +1,21 @@
+import { z } from 'zod'
+
+export const createUserSchema = z.object({
+  username: z
+    .string()
+    .min(1, { error: 'Username is required' })
+    .min(3, { error: 'Username must be at least 3 characters long' })
+    .max(50, { error: 'Username must not exceed 50 characters' })
+    .regex(/^[a-zA-Z0-9_]+$/, {
+      error: 'Username can only contain letters, numbers, and underscores'
+    }),
+  email: z.email({ error: 'Invalid email address' }),
+  password: z
+    .string()
+    .min(1, { error: 'Password is required' })
+    .min(8, { error: 'Password must be at least 8 characters' }),
+  firstName: z.string().optional(),
+  lastName: z.string().optional()
+})
+
+export type CreateUserSchema = z.infer<typeof createUserSchema>

--- a/apps/web/src/features/admin/schemas/index.ts
+++ b/apps/web/src/features/admin/schemas/index.ts
@@ -1,0 +1,2 @@
+export { createUserSchema, type CreateUserSchema } from './createUser.schema'
+export { resetPasswordSchema, type ResetPasswordSchema } from './resetPassword.schema'

--- a/apps/web/src/features/admin/schemas/resetPassword.schema.spec.ts
+++ b/apps/web/src/features/admin/schemas/resetPassword.schema.spec.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'bun:test'
+
+import { resetPasswordSchema } from './resetPassword.schema'
+
+describe('resetPasswordSchema', () => {
+  it('validates an 8-char password', () => {
+    const result = resetPasswordSchema.safeParse({ password: 'secret12' })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects an empty password', () => {
+    const result = resetPasswordSchema.safeParse({ password: '' })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects a password shorter than 8 chars', () => {
+    const result = resetPasswordSchema.safeParse({ password: 'short' })
+    expect(result.success).toBe(false)
+  })
+})

--- a/apps/web/src/features/admin/schemas/resetPassword.schema.ts
+++ b/apps/web/src/features/admin/schemas/resetPassword.schema.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod'
+
+export const resetPasswordSchema = z.object({
+  password: z
+    .string()
+    .min(1, { error: 'Password is required' })
+    .min(8, { error: 'Password must be at least 8 characters' })
+})
+
+export type ResetPasswordSchema = z.infer<typeof resetPasswordSchema>

--- a/apps/web/src/pages/admin/users/index.astro
+++ b/apps/web/src/pages/admin/users/index.astro
@@ -17,6 +17,5 @@ if (userData.role !== 'admin') {
 ---
 
 <AdminLayout title='Manage Users'>
-  <h1 class='text-base-content mb-8 text-3xl font-bold'>Manage Users</h1>
   <UserList client:load />
 </AdminLayout>

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -13,45 +13,45 @@ Current state only. Deferred items live in [`BACKLOG.md`](./BACKLOG.md).
 
 ### Block 1: Frontend outside-in (Phases 1-5) — `feature/admin-onboarding`
 
-#### Phase 1: Shell — visible buttons wired to placeholder handlers
+#### Phase 1: Shell — visible buttons wired to placeholder handlers ✅
 
-- [ ] Move `<h1>` into `UserList` + add "Ajouter un user" button (placeholder handler) + spec
+- [x] Move `<h1>` into `UserList` + add "Ajouter un user" button (placeholder handler) + spec
       assertions for title and button presence
-- [ ] Extend `UserManagement` with "Valider l'email" (conditional on `!emailVerified`) and
+- [x] Extend `UserManagement` with "Valider l'email" (conditional on `!emailVerified`) and
       "Réinitialiser le password" buttons (placeholder handlers) + spec assertions for conditional
       render
 
-#### Phase 2: Zod schemas (create + reset) + barrel
+#### Phase 2: Zod schemas (create + reset) + barrel ✅
 
-- [ ] `createUser.schema.ts` + spec — reuses signup rules verbatim (username 3-50 alnum/underscore,
+- [x] `createUser.schema.ts` + spec — reuses signup rules verbatim (username 3-50 alnum/underscore,
       email, password min 8), `firstName` / `lastName` optional
-- [ ] `resetPassword.schema.ts` + spec — single password field, min 8, no confirm
-- [ ] `features/admin/schemas/index.ts` barrel
+- [x] `resetPassword.schema.ts` + spec — single password field, min 8, no confirm
+- [x] `features/admin/schemas/index.ts` barrel
 
-#### Phase 3: Create User flow (form + dialog + wiring)
+#### Phase 3: Create User flow (form + dialog + wiring) ✅
 
-- [ ] `CreateUserForm` component + spec — 5 fields (username, email, password, firstName?,
+- [x] `CreateUserForm` component + spec — 5 fields (username, email, password, firstName?,
       lastName?), password rendered as `type='text'` so admin can read before transmitting
       out-of-band
-- [ ] `CreateUserDialog` component + spec — Radix dialog wrapper (reuses `DialogShell` +
+- [x] `CreateUserDialog` component + spec — Radix dialog wrapper (reuses `DialogShell` +
       `FormWrapper`), RHF + Zod resolver, inline server error surface
-- [ ] Wire create flow in `UserList` (`admin.createUser` with `data` spread for custom fields +
+- [x] Wire create flow in `UserList` (`admin.createUser` with `data` spread for custom fields +
       `emailVerified: true`, `name` computed from first+last or username fallback, redirect to
       `/admin/users/:id`) + spec update
 
-#### Phase 4: Verify email action
+#### Phase 4: Verify email action ✅
 
-- [ ] Wire `handleVerify` in `UserManagement`
+- [x] Wire `handleVerify` in `UserManagement`
       (`admin.updateUser({ userId, data: { emailVerified:     true } })`, local state update flips
       badge + hides button, inline success alert) + spec update
 
-#### Phase 5: Reset Password flow (form + dialog + wiring)
+#### Phase 5: Reset Password flow (form + dialog + wiring) ✅
 
-- [ ] `ResetPasswordForm` component + spec — single password field rendered as `type='text'`
-- [ ] `ResetPasswordDialog` component + spec — dialog body description includes the out-of-band
+- [x] `ResetPasswordForm` component + spec — single password field rendered as `type='text'`
+- [x] `ResetPasswordDialog` component + spec — dialog body description includes the out-of-band
       reminder (`"n'est envoyé à personne — transmettez-le vous-même au testeur"`), RHF + Zod
       resolver, inline server error surface
-- [ ] Wire reset flow in `UserManagement` (`admin.setUserPassword`, inline success alert that
+- [x] Wire reset flow in `UserManagement` (`admin.setUserPassword`, inline success alert that
       reminds admin to transmit the new password out-of-band) + spec update
 
 ---


### PR DESCRIPTION
## Summary

Feature 08: Admin Onboarding — three admin-only actions on the existing user management UI, all client-only via the Better Auth 1.5.5 admin plugin. Zero backend changes. Unblocks external tester onboarding without email infrastructure.

- **Create user** — dialog on `/admin/users` creates a Better Auth user via `admin.createUser({ email, password, name, data: { username, firstName, lastName, emailVerified: true } })` and redirects to the new detail page. `name` computed from first+last or username fallback.
- **Verify email** — conditional button on `/admin/users/:id` calls `admin.updateUser({ userId, data: { emailVerified: true } })`, flips the badge and hides the button via local state.
- **Reset password** — dialog on `/admin/users/:id` calls `admin.setUserPassword({ userId, newPassword })`. Password field is `type='text'` so the admin can read before transmitting out-of-band. Success alert explicitly reminds that the password is not emailed — admin must transmit it themselves.

Implementation follows the feature shape (`docs/features/08-admin-onboarding.md`) and plan (`~/.claude/plans/car-cost-tracker-08-admin-onboarding.md`) verbatim.

## Changes

- 5 new files in `features/admin/schemas/` — createUser + resetPassword Zod schemas (9 spec tests)
- 8 new files in `features/admin/components/` — CreateUserForm/Dialog, ResetPasswordForm/Dialog (13 spec tests)
- `features/admin/components/UserList.tsx` + spec — header with create button, dialog wiring, admin.createUser handler (5 new tests)
- `features/admin/components/UserManagement.tsx` + spec — Valider l'email (conditional) + Réinitialiser le password actions, handleVerify, handleResetPassword (7 new tests)
- `pages/admin/users/index.astro` — removed duplicate h1 (now owned by UserList)
- `docs/PROGRESS.md` — Phase 1-5 checkboxes marked ✅

Net: 14 new files, 5 modified, 37 new tests. Total suite: 1012 pass / 0 fail.

## Test plan

- [x] Unit: `bun run test` (1012/1012 pass)
- [x] Type check: `bun run typecheck` (clean)
- [x] Lint: `bun run lint:check` (clean)
- [x] Format: `bun run format:check` (clean)
- [x] Manual: create a tester user from `/admin/users` → verify redirect → confirm new user can log in with provided password + is already verified
- [x] Manual: for an unverified user, click "Valider l'email" → badge flips to Verified, button disappears, success alert shown
- [x] Manual: click "Réinitialiser le password" → dialog shows out-of-band reminder → submit → success alert reminds to transmit password manually
- [x] Manual: submit create/reset with duplicate email or invalid data → inline server error in dialog, dialog stays open

## Review notes

- Code review done pre-commit (superpowers:code-reviewer) — 1 Important finding addressed (`handleResetPassword` prologue/loading state now consistent with other handlers), minor findings acknowledged.
- `emailVerified: true` on creation is deliberate per the feature shape trust model (admin creates trusted testers).
- `type='text'` on passwords is deliberate and tested — admin must read before out-of-band transmission.