### PR TITLE
feature: visual refresh — vehicles cluster + mileage history

### DIFF
--- a/apps/web/src/features/dashboard/components/VehicleSummaryCard.spec.tsx
+++ b/apps/web/src/features/dashboard/components/VehicleSummaryCard.spec.tsx
@@ -37,7 +37,7 @@ describe('VehicleSummaryCard', () => {
     render(<VehicleSummaryCard vehicle={mockVehicle} />)
 
     expect(screen.getByText(/1990/)).toBeInTheDocument()
-    expect(screen.getByText(/120000 kms/)).toBeInTheDocument()
+    expect(screen.getByText(/120000 km/)).toBeInTheDocument()
   })
 
   it('renders a details link pointing to /vehicle', () => {

--- a/apps/web/src/features/vehicles/components/MileageHistoryCard.spec.tsx
+++ b/apps/web/src/features/vehicles/components/MileageHistoryCard.spec.tsx
@@ -1,0 +1,92 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+
+import { act, cleanup, render, screen } from '~/test-utils'
+
+import { $mileageHistoryTick } from '../store'
+import type { MileageHistoryEntry } from '../utils'
+
+import { MileageHistoryCard } from './MileageHistoryCard'
+
+const VEHICLE_ID = 'v-card'
+const KEY = `mileage-history:${VEHICLE_ID}`
+
+const buildEntry = (overrides: Partial<MileageHistoryEntry> = {}): MileageHistoryEntry => ({
+  recordedAt: '2026-04-26T10:00:00.000Z',
+  mileage: 100,
+  delta: 10,
+  ...overrides
+})
+
+const seed = (entries: MileageHistoryEntry[]) => {
+  window.localStorage.setItem(KEY, JSON.stringify(entries))
+  act(() => {
+    $mileageHistoryTick.set($mileageHistoryTick.get() + 1)
+  })
+}
+
+describe('MileageHistoryCard', () => {
+  beforeEach(() => {
+    cleanup()
+    document.body.innerHTML = ''
+    window.localStorage.clear()
+    act(() => {
+      $mileageHistoryTick.set(0)
+    })
+  })
+
+  afterEach(() => {
+    window.localStorage.clear()
+    act(() => {
+      $mileageHistoryTick.set(0)
+    })
+  })
+
+  it('should render the kicker label', () => {
+    render(<MileageHistoryCard vehicleId={VEHICLE_ID} />)
+
+    expect(screen.getByText(/historique compteur/i)).toBeInTheDocument()
+  })
+
+  it('should render the empty state when no entries exist', () => {
+    render(<MileageHistoryCard vehicleId={VEHICLE_ID} />)
+
+    expect(screen.getByText(/aucune mise à jour/i)).toBeInTheDocument()
+  })
+
+  it('should render entries with date, mileage, and delta', () => {
+    seed([
+      buildEntry({
+        recordedAt: '2026-04-26T10:00:00.000Z',
+        mileage: 92500,
+        delta: 200
+      })
+    ])
+
+    render(<MileageHistoryCard vehicleId={VEHICLE_ID} />)
+
+    expect(screen.getByText('92500 km')).toBeInTheDocument()
+    expect(screen.getByText('+ 200')).toBeInTheDocument()
+    const timeElement = screen.getByText('26/04/2026')
+    expect(timeElement.tagName).toBe('TIME')
+    expect(timeElement).toHaveAttribute('datetime', '2026-04-26T10:00:00.000Z')
+  })
+
+  it('should cap visible entries at 10 even when more are stored', () => {
+    const entries = Array.from({ length: 15 }, (_, index) =>
+      buildEntry({ mileage: 1000 + index, recordedAt: `2026-04-${10 + index}T10:00:00.000Z` })
+    )
+    seed(entries)
+
+    render(<MileageHistoryCard vehicleId={VEHICLE_ID} />)
+
+    expect(screen.getAllByRole('listitem')).toHaveLength(10)
+  })
+
+  it('should not render the empty state once entries exist', () => {
+    seed([buildEntry()])
+
+    render(<MileageHistoryCard vehicleId={VEHICLE_ID} />)
+
+    expect(screen.queryByText(/aucune mise à jour/i)).not.toBeInTheDocument()
+  })
+})

--- a/apps/web/src/features/vehicles/components/MileageHistoryCard.tsx
+++ b/apps/web/src/features/vehicles/components/MileageHistoryCard.tsx
@@ -1,0 +1,43 @@
+import { useMileageHistory } from '../hooks'
+import { formatDate, formatMileage } from '../utils'
+
+const VISIBLE_LIMIT = 10
+
+export interface MileageHistoryCardProps {
+  vehicleId: string
+}
+
+export const MileageHistoryCard = ({ vehicleId }: MileageHistoryCardProps) => {
+  const { entries } = useMileageHistory(vehicleId)
+  const visible = entries.slice(0, VISIBLE_LIMIT)
+
+  return (
+    <article className='border-base-300 bg-base-200 border'>
+      <header className='border-base-300 border-b p-4'>
+        <p className='text-base-content/60 font-mono text-xs tracking-widest uppercase'>
+          Historique compteur
+        </p>
+      </header>
+      {visible.length === 0 ? (
+        <p className='text-base-content/60 p-4 font-mono text-sm'>
+          Aucune mise à jour enregistrée pour le moment.
+        </p>
+      ) : (
+        <ul className='divide-base-300 divide-y'>
+          {visible.map(entry => (
+            <li
+              className='grid grid-cols-[1fr_1fr_auto] items-center gap-4 p-4'
+              key={`${entry.recordedAt}-${entry.mileage}`}
+            >
+              <time dateTime={entry.recordedAt} className='text-base-content/80 font-mono text-sm'>
+                {formatDate(entry.recordedAt)}
+              </time>
+              <span className='text-primary font-mono text-sm'>{formatMileage(entry.mileage)}</span>
+              <span className='text-success font-mono text-sm'>+ {entry.delta}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </article>
+  )
+}

--- a/apps/web/src/features/vehicles/components/QuickMileageUpdate.spec.tsx
+++ b/apps/web/src/features/vehicles/components/QuickMileageUpdate.spec.tsx
@@ -1,6 +1,6 @@
-import { beforeEach, describe, expect, it } from 'bun:test'
+import { beforeEach, describe, expect, it, mock } from 'bun:test'
 
-import { cleanup, render, screen } from '~/test-utils'
+import { cleanup, fireEvent, render, screen, userEvent, waitFor } from '~/test-utils'
 
 import { QuickMileageUpdate } from './QuickMileageUpdate'
 
@@ -10,25 +10,76 @@ describe('QuickMileageUpdate', () => {
     document.body.innerHTML = ''
   })
 
-  it('should render a mileage input pre-filled with currentMileage', () => {
+  it('should render the cluster kicker label', () => {
     render(<QuickMileageUpdate currentMileage={75000} onSubmit={() => {}} />)
 
-    const input = screen.getByLabelText(/Kilométrage/i)
+    expect(screen.getByText(/compteur kilométrique/i)).toBeInTheDocument()
+  })
 
+  it('should render the current mileage in the inner panel', () => {
+    render(<QuickMileageUpdate currentMileage={75000} onSubmit={() => {}} />)
+
+    expect(screen.getByText('75000 km')).toBeInTheDocument()
+    expect(screen.getByText(/kilomètres actuels/i)).toBeInTheDocument()
+  })
+
+  it('should render the Nouvelle valeur input pre-filled with currentMileage', () => {
+    render(<QuickMileageUpdate currentMileage={75000} onSubmit={() => {}} />)
+
+    const input = screen.getByLabelText('Nouvelle valeur')
     expect(input).toBeInTheDocument()
     expect(input).toHaveValue(75000)
   })
 
-  it('should render a submit button', () => {
+  it('should render a Valider submit button', () => {
     render(<QuickMileageUpdate currentMileage={75000} onSubmit={() => {}} />)
 
-    const submitButton = screen.getByRole('button', { name: /Mettre à jour/i })
-    expect(submitButton).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /valider/i })).toBeInTheDocument()
   })
 
-  it('should display the current mileage as label context', () => {
-    render(<QuickMileageUpdate currentMileage={75000} onSubmit={() => {}} />)
+  it('should not render the live delta when watched value matches currentMileage', () => {
+    render(<QuickMileageUpdate currentMileage={100} onSubmit={() => {}} />)
 
-    expect(screen.getByText(/Kilométrage actuel : 75000 kms/i)).toBeInTheDocument()
+    expect(screen.queryByText(/^\+ \d+ km$/)).not.toBeInTheDocument()
+  })
+
+  it('should render the live delta when watched value is greater than currentMileage', async () => {
+    const user = userEvent.setup()
+    render(<QuickMileageUpdate currentMileage={100} onSubmit={() => {}} />)
+
+    const input = screen.getByLabelText('Nouvelle valeur')
+    await user.clear(input)
+    await user.type(input, '150')
+
+    expect(await screen.findByText('+ 50 km')).toBeInTheDocument()
+  })
+
+  it('should hide the live delta when watched value drops below currentMileage', async () => {
+    const user = userEvent.setup()
+    render(<QuickMileageUpdate currentMileage={100} onSubmit={() => {}} />)
+
+    const input = screen.getByLabelText('Nouvelle valeur')
+    await user.clear(input)
+    await user.type(input, '90')
+
+    expect(screen.queryByText(/\+ \d+ km/)).not.toBeInTheDocument()
+  })
+
+  it('should call onSubmit with the new mileage when Valider is clicked', async () => {
+    let received: unknown = null
+    const onSubmit = mock((data: unknown) => {
+      received = data
+    })
+    const user = userEvent.setup()
+    render(<QuickMileageUpdate currentMileage={75000} onSubmit={onSubmit} />)
+
+    const input = screen.getByLabelText('Nouvelle valeur')
+    await user.clear(input)
+    await user.type(input, '75500')
+
+    fireEvent.click(screen.getByRole('button', { name: /valider/i }))
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalled())
+    expect(received).toEqual({ mileage: 75500 })
   })
 })

--- a/apps/web/src/features/vehicles/components/QuickMileageUpdate.tsx
+++ b/apps/web/src/features/vehicles/components/QuickMileageUpdate.tsx
@@ -9,7 +9,7 @@ import { formatMileage } from '../utils'
 
 export interface QuickMileageUpdateProps {
   currentMileage: number
-  onSubmit: (data: UpdateMileageSchema) => void
+  onSubmit: (data: UpdateMileageSchema) => void | Promise<void>
 }
 
 export const QuickMileageUpdate = ({ currentMileage, onSubmit }: QuickMileageUpdateProps) => {
@@ -17,19 +17,41 @@ export const QuickMileageUpdate = ({ currentMileage, onSubmit }: QuickMileageUpd
     resolver: zodResolver(updateMileageSchema),
     defaultValues: { mileage: currentMileage }
   })
-  return (
-    <article className='card bg-base-200'>
-      <FormWrapper onSubmit={form.handleSubmit(onSubmit)} className='card-body gap-4'>
-        <h2 className='card-title'>Mise à jour du kilométrage</h2>
-        <p className='text-base-content/70'>Kilométrage actuel : {formatMileage(currentMileage)}</p>
 
+  const watched = form.watch('mileage')
+  const hasIncrease =
+    typeof watched === 'number' && Number.isFinite(watched) && watched > currentMileage
+  const delta = hasIncrease ? watched - currentMileage : null
+
+  return (
+    <article className='border-base-300 bg-base-200 border'>
+      <header className='border-base-300 border-b p-4'>
+        <p className='text-base-content/60 font-mono text-xs tracking-widest uppercase'>
+          Compteur kilométrique
+        </p>
+      </header>
+
+      <div className='border-base-300 m-4 flex flex-col gap-1 border p-4'>
+        <p className='text-primary font-mono text-4xl tracking-wider'>
+          {formatMileage(currentMileage)}
+        </p>
+        <p className='text-base-content/60 mt-1 font-mono text-xs tracking-widest uppercase'>
+          Kilomètres actuels
+        </p>
+      </div>
+
+      <FormWrapper onSubmit={form.handleSubmit(onSubmit)} className='flex flex-col gap-3 p-4 pt-0'>
         <Input
+          className='font-mono text-lg'
+          label='Nouvelle valeur'
           type='number'
-          label='Kilométrage'
           {...form.register('mileage', { valueAsNumber: true })}
           error={form.formState.errors.mileage?.message}
         />
-        <Button type='submit'>Mettre à jour</Button>
+        {delta !== null && <p className='text-success font-mono text-sm'>+ {delta} km</p>}
+        <Button className='w-full' type='submit'>
+          Valider
+        </Button>
       </FormWrapper>
     </article>
   )

--- a/apps/web/src/features/vehicles/components/VehicleContainer.spec.tsx
+++ b/apps/web/src/features/vehicles/components/VehicleContainer.spec.tsx
@@ -1,8 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test'
 
-import { cleanup, fireEvent, render, screen, userEvent, waitFor } from '~/test-utils'
+import { act, cleanup, fireEvent, render, screen, userEvent, waitFor } from '~/test-utils'
 
-import { $error, $isLoading, $vehicle, vehicleActions } from '../store'
+import { $error, $isLoading, $mileageHistoryTick, $vehicle, vehicleActions } from '../store'
 import type { Vehicle } from '../types'
 
 import { VehicleContainer } from './VehicleContainer'
@@ -33,17 +33,22 @@ describe('VehicleContainer', () => {
   beforeEach(() => {
     cleanup()
     document.body.innerHTML = ''
+    window.localStorage.clear()
 
-    // Reset store atoms to default loading state
     $vehicle.set(null)
     $isLoading.set(true)
     $error.set(null)
+    act(() => {
+      $mileageHistoryTick.set(0)
+    })
 
-    // Spy on vehicleActions to prevent real API calls
     fetchSpy = spyOn(vehicleActions, 'fetchVehicle').mockResolvedValue(undefined)
     createSpy = spyOn(vehicleActions, 'create').mockResolvedValue(mockVehicle)
     updateSpy = spyOn(vehicleActions, 'update').mockResolvedValue(mockVehicle)
-    updateMileageSpy = spyOn(vehicleActions, 'updateMileage').mockResolvedValue(mockVehicle)
+    updateMileageSpy = spyOn(vehicleActions, 'updateMileage').mockResolvedValue({
+      ...mockVehicle,
+      mileage: 92500
+    })
     removeSpy = spyOn(vehicleActions, 'remove').mockResolvedValue(undefined)
   })
 
@@ -53,6 +58,7 @@ describe('VehicleContainer', () => {
     updateSpy.mockRestore()
     updateMileageSpy.mockRestore()
     removeSpy.mockRestore()
+    window.localStorage.clear()
   })
 
   describe('loading + empty mode', () => {
@@ -78,30 +84,31 @@ describe('VehicleContainer', () => {
   })
 
   describe('create mode', () => {
-    it('should display a title in create mode', () => {
+    it('should display the create-mode kicker and heading', () => {
       $isLoading.set(false)
 
       render(<VehicleContainer />)
-      fireEvent.click(screen.getByText('Ajouter mon véhicule'))
+      fireEvent.click(screen.getByRole('button', { name: /ajouter mon véhicule/i }))
 
-      expect(screen.getByText('Ajouter mon véhicule')).toBeInTheDocument()
+      expect(screen.getByText(/créer votre fiche/i)).toBeInTheDocument()
+      expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(/ajouter mon véhicule/i)
     })
 
     it('should switch to create form when "Ajouter" is clicked', () => {
       $isLoading.set(false)
 
       render(<VehicleContainer />)
-      fireEvent.click(screen.getByText('Ajouter mon véhicule'))
+      fireEvent.click(screen.getByRole('button', { name: /ajouter mon véhicule/i }))
 
-      expect(screen.getByText('Enregistrer')).toBeInTheDocument()
-      expect(screen.getByText('Annuler')).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: /enregistrer/i })).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: /annuler/i })).toBeInTheDocument()
     })
 
     it('should render all form fields in create mode', () => {
       $isLoading.set(false)
 
       render(<VehicleContainer />)
-      fireEvent.click(screen.getByText('Ajouter mon véhicule'))
+      fireEvent.click(screen.getByRole('button', { name: /ajouter mon véhicule/i }))
 
       expect(screen.getByLabelText('Marque', { exact: false })).toBeInTheDocument()
       expect(screen.getByLabelText('Modèle', { exact: false })).toBeInTheDocument()
@@ -118,8 +125,8 @@ describe('VehicleContainer', () => {
       $isLoading.set(false)
 
       render(<VehicleContainer />)
-      fireEvent.click(screen.getByText('Ajouter mon véhicule'))
-      fireEvent.click(screen.getByText('Annuler'))
+      fireEvent.click(screen.getByRole('button', { name: /ajouter mon véhicule/i }))
+      fireEvent.click(screen.getByRole('button', { name: /annuler/i }))
 
       expect(screen.getByText('Aucun véhicule enregistré')).toBeInTheDocument()
     })
@@ -129,7 +136,7 @@ describe('VehicleContainer', () => {
 
       const user = userEvent.setup()
       render(<VehicleContainer />)
-      fireEvent.click(screen.getByText('Ajouter mon véhicule'))
+      fireEvent.click(screen.getByRole('button', { name: /ajouter mon véhicule/i }))
 
       await user.type(screen.getByLabelText('Marque', { exact: false }), 'Mini')
       await user.type(screen.getByLabelText('Modèle', { exact: false }), 'Cooper S Coupé')
@@ -141,20 +148,22 @@ describe('VehicleContainer', () => {
       await user.type(screen.getByLabelText("Date d'achat"), '2025-07-08')
       await user.type(screen.getByLabelText('Kilométrage'), '92300')
 
-      fireEvent.click(screen.getByText('Enregistrer'))
+      fireEvent.click(screen.getByRole('button', { name: /enregistrer/i }))
 
       await waitFor(() => expect(createSpy).toHaveBeenCalled())
     })
   })
 
   describe('view mode', () => {
-    it('should display vehicle name as title in view mode', () => {
+    it('should render the view-mode heading inside the profile (no year suffix)', () => {
       $isLoading.set(false)
       $vehicle.set(mockVehicle)
 
       render(<VehicleContainer />)
 
-      expect(screen.getByText('Mini Cooper S Coupé (2012)')).toBeInTheDocument()
+      const heading = screen.getByRole('heading', { level: 1 })
+      expect(heading).toHaveTextContent(/mini cooper s coupé/i)
+      expect(heading).not.toHaveTextContent(/\(2012\)/)
     })
 
     it('should show VehicleProfile when vehicle exists', () => {
@@ -168,27 +177,44 @@ describe('VehicleContainer', () => {
       expect(screen.getByText('Année')).toBeInTheDocument()
     })
 
-    it('should show QuickMileageUpdate below the profile', () => {
+    it('should show QuickMileageUpdate alongside the profile', () => {
       $isLoading.set(false)
       $vehicle.set(mockVehicle)
 
       render(<VehicleContainer />)
 
-      expect(screen.getByLabelText('Kilométrage')).toBeInTheDocument()
-      expect(screen.getByText('Mettre à jour')).toBeInTheDocument()
+      expect(screen.getByLabelText('Nouvelle valeur')).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: /valider/i })).toBeInTheDocument()
     })
 
-    it('should call updateMileage when mileage form is submitted', async () => {
+    it('should render MileageHistoryCard with its empty state on first visit', () => {
+      $isLoading.set(false)
+      $vehicle.set(mockVehicle)
+
+      render(<VehicleContainer />)
+
+      expect(screen.getByText(/historique compteur/i)).toBeInTheDocument()
+      expect(screen.getByText(/aucune mise à jour/i)).toBeInTheDocument()
+    })
+
+    it('should call updateMileage and append a history entry when a higher value is submitted', async () => {
       $isLoading.set(false)
       $vehicle.set(mockVehicle)
 
       const user = userEvent.setup()
       render(<VehicleContainer />)
 
-      await user.type(screen.getByLabelText('Kilométrage'), '92305')
-      fireEvent.click(screen.getByText('Mettre à jour'))
+      const input = screen.getByLabelText('Nouvelle valeur')
+      await user.clear(input)
+      await user.type(input, '92500')
+      fireEvent.click(screen.getByRole('button', { name: /valider/i }))
 
       await waitFor(() => expect(updateMileageSpy).toHaveBeenCalled())
+      await waitFor(() => {
+        expect(screen.queryByText(/aucune mise à jour/i)).not.toBeInTheDocument()
+      })
+      expect(screen.getByText('92500 km')).toBeInTheDocument()
+      expect(screen.getByText('+ 200')).toBeInTheDocument()
     })
   })
 
@@ -198,20 +224,22 @@ describe('VehicleContainer', () => {
       $vehicle.set(mockVehicle)
 
       render(<VehicleContainer />)
-      fireEvent.click(screen.getByText('Modifier'))
+      fireEvent.click(screen.getByRole('button', { name: /modifier fiche/i }))
 
-      expect(screen.getByText('Modifier Mini Cooper S Coupé (2012)')).toBeInTheDocument()
+      expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(
+        /modifier mini cooper s coupé \(2012\)/i
+      )
     })
 
-    it('should switch to edit form when "Modifier" is clicked', () => {
+    it('should switch to edit form when "Modifier fiche" is clicked', () => {
       $isLoading.set(false)
       $vehicle.set(mockVehicle)
 
       render(<VehicleContainer />)
-      fireEvent.click(screen.getByText('Modifier'))
+      fireEvent.click(screen.getByRole('button', { name: /modifier fiche/i }))
 
-      expect(screen.getByText('Enregistrer')).toBeInTheDocument()
-      expect(screen.getByText('Annuler')).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: /enregistrer/i })).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: /annuler/i })).toBeInTheDocument()
     })
 
     it('should pre-fill form with vehicle data', () => {
@@ -219,7 +247,7 @@ describe('VehicleContainer', () => {
       $vehicle.set(mockVehicle)
 
       render(<VehicleContainer />)
-      fireEvent.click(screen.getByText('Modifier'))
+      fireEvent.click(screen.getByRole('button', { name: /modifier fiche/i }))
 
       expect(screen.getByDisplayValue('Mini')).toBeInTheDocument()
       expect(screen.getByDisplayValue('Cooper S Coupé')).toBeInTheDocument()
@@ -231,7 +259,7 @@ describe('VehicleContainer', () => {
       $vehicle.set(mockVehicle)
 
       render(<VehicleContainer />)
-      fireEvent.click(screen.getByText('Modifier'))
+      fireEvent.click(screen.getByRole('button', { name: /modifier fiche/i }))
 
       expect(screen.queryByLabelText('Kilométrage')).not.toBeInTheDocument()
     })
@@ -241,8 +269,8 @@ describe('VehicleContainer', () => {
       $vehicle.set(mockVehicle)
 
       render(<VehicleContainer />)
-      fireEvent.click(screen.getByText('Modifier'))
-      fireEvent.click(screen.getByText('Annuler'))
+      fireEvent.click(screen.getByRole('button', { name: /modifier fiche/i }))
+      fireEvent.click(screen.getByRole('button', { name: /annuler/i }))
 
       expect(screen.getByText('Marque')).toBeInTheDocument()
       expect(screen.getByText('Modèle')).toBeInTheDocument()
@@ -255,10 +283,10 @@ describe('VehicleContainer', () => {
 
       const user = userEvent.setup()
       render(<VehicleContainer />)
-      fireEvent.click(screen.getByText('Modifier'))
+      fireEvent.click(screen.getByRole('button', { name: /modifier fiche/i }))
 
       await user.type(screen.getByLabelText('Type de moteur'), '1.6l Turbo')
-      fireEvent.click(screen.getByText('Enregistrer'))
+      fireEvent.click(screen.getByRole('button', { name: /enregistrer/i }))
 
       await waitFor(() => expect(updateSpy).toHaveBeenCalled())
     })
@@ -279,7 +307,7 @@ describe('VehicleContainer', () => {
       $vehicle.set(mockVehicle)
 
       render(<VehicleContainer />)
-      fireEvent.click(screen.getByText('Supprimer'))
+      fireEvent.click(screen.getByRole('button', { name: /^supprimer$/i }))
 
       expect(screen.getByText('Supprimer le véhicule')).toBeInTheDocument()
     })
@@ -289,8 +317,8 @@ describe('VehicleContainer', () => {
       $vehicle.set(mockVehicle)
 
       render(<VehicleContainer />)
-      fireEvent.click(screen.getByText('Supprimer'))
-      fireEvent.click(screen.getByText('Annuler'))
+      fireEvent.click(screen.getByRole('button', { name: /^supprimer$/i }))
+      fireEvent.click(screen.getByRole('button', { name: /annuler/i }))
 
       expect(screen.queryByText('Supprimer le véhicule')).not.toBeInTheDocument()
     })
@@ -300,9 +328,9 @@ describe('VehicleContainer', () => {
       $vehicle.set(mockVehicle)
 
       render(<VehicleContainer />)
-      fireEvent.click(screen.getByText('Supprimer'))
-      const dialogDeleteButton = screen.getAllByText('Supprimer')[1]
-      fireEvent.click(dialogDeleteButton)
+      fireEvent.click(screen.getByRole('button', { name: /^supprimer$/i }))
+      const confirmButtons = screen.getAllByRole('button', { name: /^supprimer$/i })
+      fireEvent.click(confirmButtons[confirmButtons.length - 1] as HTMLElement)
 
       await waitFor(() => expect(removeSpy).toHaveBeenCalled())
     })
@@ -315,10 +343,26 @@ describe('VehicleContainer', () => {
       updateSpy.mockRejectedValueOnce(new Error('Update failed'))
 
       render(<VehicleContainer />)
-      fireEvent.click(screen.getByText('Modifier'))
-      fireEvent.click(screen.getByText('Enregistrer'))
+      fireEvent.click(screen.getByRole('button', { name: /modifier fiche/i }))
+      fireEvent.click(screen.getByRole('button', { name: /enregistrer/i }))
 
       await waitFor(() => expect(screen.getByText('Update failed')).toBeInTheDocument())
+    })
+
+    it('should display server error when updateMileage fails', async () => {
+      $isLoading.set(false)
+      $vehicle.set(mockVehicle)
+      updateMileageSpy.mockRejectedValueOnce(new Error('Mileage update failed'))
+
+      const user = userEvent.setup()
+      render(<VehicleContainer />)
+
+      const input = screen.getByLabelText('Nouvelle valeur')
+      await user.clear(input)
+      await user.type(input, '92500')
+      fireEvent.click(screen.getByRole('button', { name: /valider/i }))
+
+      await waitFor(() => expect(screen.getByText('Mileage update failed')).toBeInTheDocument())
     })
   })
 })

--- a/apps/web/src/features/vehicles/components/VehicleContainer.tsx
+++ b/apps/web/src/features/vehicles/components/VehicleContainer.tsx
@@ -4,11 +4,12 @@ import { useForm } from 'react-hook-form'
 
 import { Button, FormWrapper } from '~/components/ui'
 
-import { useVehicle } from '../hooks'
+import { useMileageHistory, useVehicle } from '../hooks'
 import type { CreateVehicleSchema, UpdateMileageSchema } from '../schemas'
 import { createVehicleSchema } from '../schemas'
 
 import { DeleteVehicleDialog } from './DeleteVehicleDialog'
+import { MileageHistoryCard } from './MileageHistoryCard'
 import { QuickMileageUpdate } from './QuickMileageUpdate'
 import { VehicleEmptyState } from './VehicleEmptyState'
 import { VehicleForm } from './VehicleForm'
@@ -25,6 +26,7 @@ export const VehicleContainer = () => {
     updateVehicle,
     deleteVehicle
   } = useVehicle()
+  const { append: appendMileageEntry } = useMileageHistory(vehicle?.id)
   const [mode, setMode] = useState<'loading' | 'empty' | 'create' | 'view' | 'edit'>('loading')
   const [showDeleteDialog, setShowDeleteDialog] = useState(false)
   const [serverError, setServerError] = useState<string | null>(null)
@@ -88,8 +90,23 @@ export const VehicleContainer = () => {
     fetchVehicle()
   }, [fetchVehicle])
 
-  const handleQuickMileageSubmit = async (mileage: UpdateMileageSchema) => {
-    await updateMileage(vehicle!.id, mileage)
+  const handleQuickMileageSubmit = async (input: UpdateMileageSchema) => {
+    if (!vehicle) return
+    setServerError(null)
+    const previousMileage = vehicle.mileage
+    try {
+      await updateMileage(vehicle.id, input)
+      const delta = input.mileage - previousMileage
+      if (delta > 0) {
+        appendMileageEntry({
+          recordedAt: new Date().toISOString(),
+          mileage: input.mileage,
+          delta
+        })
+      }
+    } catch (error) {
+      setServerError(error instanceof Error ? error.message : 'Une erreur est survenue')
+    }
   }
 
   useEffect(() => {
@@ -109,17 +126,27 @@ export const VehicleContainer = () => {
   if (mode === 'create') {
     return (
       <>
-        <h1 className='text-base-content mb-8 text-center text-4xl font-bold'>
-          Ajouter mon véhicule
-        </h1>
-        <article className='card bg-base-200 mx-auto max-w-2xl'>
-          <FormWrapper onSubmit={handleSubmit} error={serverError} className='card-body gap-4'>
+        <header className='mb-8'>
+          <p className='text-base-content/60 font-mono text-xs tracking-widest uppercase'>
+            Créer votre fiche
+          </p>
+          <h1 className='font-display text-3xl md:text-4xl'>Ajouter mon véhicule</h1>
+        </header>
+        <article className='border-base-300 bg-base-200 border p-6'>
+          <FormWrapper onSubmit={handleSubmit} error={serverError} className='flex flex-col gap-4'>
             <VehicleForm form={form} showMileage={true} />
-            <section className='card-actions justify-between'>
-              <Button type='button' variant='destructive' onClick={onCancel}>
+            <section className='flex flex-wrap justify-between gap-3'>
+              <Button
+                type='button'
+                variant='destructive'
+                className='btn-outline w-full md:w-auto'
+                onClick={onCancel}
+              >
                 Annuler
               </Button>
-              <Button type='submit'>Enregistrer</Button>
+              <Button type='submit' className='w-full md:w-auto'>
+                Enregistrer
+              </Button>
             </section>
           </FormWrapper>
         </article>
@@ -130,19 +157,29 @@ export const VehicleContainer = () => {
   if (mode === 'view' && vehicle) {
     return (
       <>
-        <h1 className='text-base-content mb-8 text-center text-4xl font-bold'>
-          {vehicle.make} {vehicle.model} ({vehicle.year})
-        </h1>
-        <div className='mx-auto flex max-w-2xl flex-col gap-6'>
-          <VehicleProfile
-            vehicle={vehicle}
-            onEdit={onEdit}
-            onDelete={() => setShowDeleteDialog(true)}
-          />
-          <QuickMileageUpdate
-            currentMileage={vehicle.mileage}
-            onSubmit={handleQuickMileageSubmit}
-          />
+        {serverError && (
+          <p
+            className='border-error bg-error/10 text-error mb-4 border p-3 font-mono text-sm'
+            role='alert'
+          >
+            {serverError}
+          </p>
+        )}
+        <div className='grid grid-cols-1 gap-6 lg:grid-cols-3'>
+          <div className='lg:col-span-2'>
+            <VehicleProfile
+              vehicle={vehicle}
+              onEdit={onEdit}
+              onDelete={() => setShowDeleteDialog(true)}
+            />
+          </div>
+          <aside className='flex flex-col gap-6 lg:col-span-1'>
+            <QuickMileageUpdate
+              currentMileage={vehicle.mileage}
+              onSubmit={handleQuickMileageSubmit}
+            />
+            <MileageHistoryCard vehicleId={vehicle.id} />
+          </aside>
         </div>
         {showDeleteDialog && (
           <DeleteVehicleDialog
@@ -158,17 +195,29 @@ export const VehicleContainer = () => {
   if (mode === 'edit' && vehicle) {
     return (
       <>
-        <h1 className='text-base-content mb-8 text-center text-4xl font-bold'>
-          Modifier {vehicle.make} {vehicle.model} ({vehicle.year})
-        </h1>
-        <article className='card bg-base-200 mx-auto max-w-2xl'>
-          <FormWrapper onSubmit={handleSubmit} error={serverError} className='card-body gap-4'>
+        <header className='mb-8'>
+          <p className='text-base-content/60 font-mono text-xs tracking-widest uppercase'>
+            Modifier fiche
+          </p>
+          <h1 className='font-display text-3xl md:text-4xl'>
+            Modifier {vehicle.make} {vehicle.model} ({vehicle.year})
+          </h1>
+        </header>
+        <article className='border-base-300 bg-base-200 border p-6'>
+          <FormWrapper onSubmit={handleSubmit} error={serverError} className='flex flex-col gap-4'>
             <VehicleForm form={form} showMileage={false} />
-            <section className='card-actions justify-between'>
-              <Button type='button' variant='destructive' onClick={onCancel}>
+            <section className='flex flex-wrap justify-between gap-3'>
+              <Button
+                type='button'
+                variant='destructive'
+                className='btn-outline w-full md:w-auto'
+                onClick={onCancel}
+              >
                 Annuler
               </Button>
-              <Button type='submit'>Enregistrer</Button>
+              <Button type='submit' className='w-full md:w-auto'>
+                Enregistrer
+              </Button>
             </section>
           </FormWrapper>
         </article>

--- a/apps/web/src/features/vehicles/components/VehicleEmptyState.spec.tsx
+++ b/apps/web/src/features/vehicles/components/VehicleEmptyState.spec.tsx
@@ -10,6 +10,13 @@ describe('VehicleEmptyState', () => {
     document.body.innerHTML = ''
   })
 
+  it('should render the cluster kicker label', () => {
+    const action = mock(() => {})
+    render(<VehicleEmptyState onCreateClick={action} />)
+
+    expect(screen.getByText(/créer votre fiche/i)).toBeInTheDocument()
+  })
+
   it('should render a heading message', () => {
     const action = mock(() => {})
     render(<VehicleEmptyState onCreateClick={action} />)

--- a/apps/web/src/features/vehicles/components/VehicleEmptyState.tsx
+++ b/apps/web/src/features/vehicles/components/VehicleEmptyState.tsx
@@ -7,13 +7,16 @@ export interface VehicleEmptyStateProps {
 }
 
 export const VehicleEmptyState = ({ onCreateClick }: VehicleEmptyStateProps) => (
-  <section className='flex flex-col items-center gap-3 py-16 text-center'>
-    <Car size={48} className='text-base-content/30' aria-hidden='true' />
-    <p className='text-base-content/70 text-lg font-medium'>Aucun véhicule enregistré</p>
-    <p className='text-base-content/60 max-w-sm text-sm'>
+  <section className='flex flex-col items-center gap-3 py-12 text-center'>
+    <p className='text-base-content/60 font-mono text-xs tracking-widest uppercase'>
+      Créer votre fiche
+    </p>
+    <Car aria-hidden='true' className='text-base-content/40' size={48} />
+    <p className='text-base-content text-lg font-medium'>Aucun véhicule enregistré</p>
+    <p className='text-base-content/60 max-w-sm font-mono text-sm'>
       Ajoutez votre premier véhicule pour commencer.
     </p>
-    <Button onClick={onCreateClick} className='mt-4'>
+    <Button className='mt-4 w-full md:w-auto' onClick={onCreateClick}>
       Ajouter mon véhicule
     </Button>
   </section>

--- a/apps/web/src/features/vehicles/components/VehicleForm.tsx
+++ b/apps/web/src/features/vehicles/components/VehicleForm.tsx
@@ -7,6 +7,9 @@ import { FUEL_TYPE_LABELS } from '../types'
 
 const fuelTypeOptions = Object.entries(FUEL_TYPE_LABELS).map(([value, label]) => ({ value, label }))
 
+const legendClasses =
+  'text-base-content/60 col-span-full mb-3 font-mono text-xs tracking-widest uppercase'
+
 export interface VehicleFormProps {
   form: UseFormReturn<CreateVehicleSchema>
   showMileage?: boolean
@@ -14,8 +17,8 @@ export interface VehicleFormProps {
 
 export const VehicleForm = ({ form, showMileage = true }: VehicleFormProps) => (
   <>
-    <fieldset className='fieldset grid grid-cols-1 gap-4 md:grid-cols-2'>
-      <legend className='fieldset-legend col-span-full'>Identité du véhicule</legend>
+    <fieldset className='grid grid-cols-1 gap-4 md:grid-cols-2'>
+      <legend className={legendClasses}>Identité du véhicule</legend>
       <Input
         label='Marque'
         required
@@ -30,8 +33,8 @@ export const VehicleForm = ({ form, showMileage = true }: VehicleFormProps) => (
       />
     </fieldset>
 
-    <fieldset className='fieldset grid grid-cols-1 gap-4 md:grid-cols-3'>
-      <legend className='fieldset-legend col-span-full'>Caractéristiques techniques</legend>
+    <fieldset className='grid grid-cols-1 gap-4 md:grid-cols-3'>
+      <legend className={legendClasses}>Caractéristiques techniques</legend>
       <Input
         label='Année'
         type='number'
@@ -55,8 +58,8 @@ export const VehicleForm = ({ form, showMileage = true }: VehicleFormProps) => (
 
     <Input label='VIN' {...form.register('vin')} error={form.formState.errors.vin?.message} />
 
-    <fieldset className='fieldset grid grid-cols-1 gap-4 md:grid-cols-2'>
-      <legend className='fieldset-legend col-span-full'>Informations administratives</legend>
+    <fieldset className='grid grid-cols-1 gap-4 md:grid-cols-2'>
+      <legend className={legendClasses}>Informations administratives</legend>
       <Input
         label="Plaque d'immatriculation"
         {...form.register('licensePlate')}
@@ -71,9 +74,10 @@ export const VehicleForm = ({ form, showMileage = true }: VehicleFormProps) => (
     </fieldset>
 
     {showMileage && (
-      <fieldset className='fieldset'>
-        <legend className='fieldset-legend col-span-full'>Usage</legend>
+      <fieldset>
+        <legend className={legendClasses}>Usage</legend>
         <Input
+          className='font-mono text-lg'
           label='Kilométrage'
           type='number'
           {...form.register('mileage', { valueAsNumber: true })}

--- a/apps/web/src/features/vehicles/components/VehicleProfile.spec.tsx
+++ b/apps/web/src/features/vehicles/components/VehicleProfile.spec.tsx
@@ -100,7 +100,7 @@ describe('VehicleProfile', () => {
     expect(screen.getByText('75000 km')).toBeInTheDocument()
   })
 
-  it('should display mileage with km singular or plural suffix', () => {
+  it('should display mileage with the invariant km suffix', () => {
     const actions = mock(() => {})
     const vehicleWith1Km: Vehicle = { ...mockVehicle, mileage: 1 }
     render(<VehicleProfile vehicle={vehicleWith1Km} onEdit={actions} onDelete={actions} />)

--- a/apps/web/src/features/vehicles/components/VehicleProfile.spec.tsx
+++ b/apps/web/src/features/vehicles/components/VehicleProfile.spec.tsx
@@ -28,6 +28,45 @@ describe('VehicleProfile', () => {
     document.body.innerHTML = ''
   })
 
+  it('should render the cluster kicker label', () => {
+    const actions = mock(() => {})
+    render(<VehicleProfile vehicle={mockVehicle} onEdit={actions} onDelete={actions} />)
+
+    expect(screen.getByText(/fiche véhicule/i)).toBeInTheDocument()
+  })
+
+  it('should render the make and model in the level-1 heading', () => {
+    const actions = mock(() => {})
+    render(<VehicleProfile vehicle={mockVehicle} onEdit={actions} onDelete={actions} />)
+
+    const heading = screen.getByRole('heading', { level: 1 })
+    expect(heading).toHaveTextContent(/mini cooper s/i)
+    expect(heading.tagName).toBe('H1')
+  })
+
+  it('should render the composed sub line with year and engine type', () => {
+    const actions = mock(() => {})
+    render(<VehicleProfile vehicle={mockVehicle} onEdit={actions} onDelete={actions} />)
+
+    expect(screen.getByText('— 2012 · 1.6L Turbo')).toBeInTheDocument()
+  })
+
+  it('should drop the engine type from the sub line when null', () => {
+    const actions = mock(() => {})
+    const noEngine: Vehicle = { ...mockVehicle, engineType: null }
+    render(<VehicleProfile vehicle={noEngine} onEdit={actions} onDelete={actions} />)
+
+    expect(screen.getByText('— 2012')).toBeInTheDocument()
+    expect(screen.queryByText(/1\.6L Turbo/i)).not.toBeInTheDocument()
+  })
+
+  it('should render the photo placeholder copy', () => {
+    const actions = mock(() => {})
+    render(<VehicleProfile vehicle={mockVehicle} onEdit={actions} onDelete={actions} />)
+
+    expect(screen.getByText(/dans les cartons/i)).toBeInTheDocument()
+  })
+
   it('should render all vehicle fields with French labels', () => {
     const actions = mock(() => {})
     render(<VehicleProfile vehicle={mockVehicle} onEdit={actions} onDelete={actions} />)
@@ -39,33 +78,26 @@ describe('VehicleProfile', () => {
     expect(screen.getByText('Cooper S')).toBeInTheDocument()
 
     expect(screen.getByText('Année')).toBeInTheDocument()
-    expect(screen.getByText('2012')).toBeInTheDocument()
+    // Year now appears in both the sub line and the spec grid — assert at least one is present
+    expect(screen.getAllByText(/2012/).length).toBeGreaterThan(0)
 
-    expect(screen.getByText('Type de moteur')).toBeInTheDocument()
-    expect(screen.getByText('1.6L Turbo')).toBeInTheDocument()
+    expect(screen.getByText('Type moteur')).toBeInTheDocument()
+    expect(screen.getAllByText(/1\.6L Turbo/i).length).toBeGreaterThan(0)
 
-    expect(screen.getByText('Type de carburant')).toBeInTheDocument()
+    expect(screen.getByText('Carburant')).toBeInTheDocument()
     expect(screen.getByText('Essence')).toBeInTheDocument()
 
     expect(screen.getByText('VIN')).toBeInTheDocument()
     expect(screen.getByText('12345678901234567')).toBeInTheDocument()
 
-    expect(screen.getByText(`Plaque d'immatriculation`)).toBeInTheDocument()
+    expect(screen.getByText('Plaque')).toBeInTheDocument()
     expect(screen.getByText('AB-123-CD')).toBeInTheDocument()
 
     expect(screen.getByText(`Date d'achat`)).toBeInTheDocument()
     expect(screen.getByText('15/06/2020')).toBeInTheDocument()
 
     expect(screen.getByText('Kilométrage')).toBeInTheDocument()
-    expect(screen.getByText('75000 kms')).toBeInTheDocument()
-  })
-
-  it('should display fuel type as translated label', () => {
-    const actions = mock(() => {})
-    render(<VehicleProfile vehicle={mockVehicle} onEdit={actions} onDelete={actions} />)
-
-    expect(screen.getByText('Type de carburant')).toBeInTheDocument()
-    expect(screen.getByText('Essence')).toBeInTheDocument()
+    expect(screen.getByText('75000 km')).toBeInTheDocument()
   })
 
   it('should display mileage with km singular or plural suffix', () => {
@@ -77,7 +109,7 @@ describe('VehicleProfile', () => {
     expect(screen.getByText('1 km')).toBeInTheDocument()
   })
 
-  it('should render "-" for nullable fields when null', () => {
+  it('should render "-" for nullable spec fields when null', () => {
     const vehicleWithNulls: Vehicle = {
       ...mockVehicle,
       engineType: null,
@@ -93,7 +125,7 @@ describe('VehicleProfile', () => {
     expect(dashes).toHaveLength(5)
   })
 
-  it('should render Edit and Delete buttons', () => {
+  it('should render Modifier fiche and Supprimer buttons', () => {
     const actions = mock(() => {})
     render(<VehicleProfile vehicle={mockVehicle} onEdit={actions} onDelete={actions} />)
 
@@ -101,7 +133,16 @@ describe('VehicleProfile', () => {
     expect(screen.getByRole('button', { name: /supprimer/i })).toBeInTheDocument()
   })
 
-  it('should call onEdit when Edit button is clicked', () => {
+  it('should describe the destructive button with the irreversible warning', () => {
+    const actions = mock(() => {})
+    render(<VehicleProfile vehicle={mockVehicle} onEdit={actions} onDelete={actions} />)
+
+    expect(screen.getByRole('button', { name: /supprimer/i })).toHaveAccessibleDescription(
+      /irréversible/i
+    )
+  })
+
+  it('should call onEdit when the Modifier fiche button is clicked', () => {
     const onEdit = mock(() => {})
     const onDelete = mock(() => {})
     render(<VehicleProfile vehicle={mockVehicle} onEdit={onEdit} onDelete={onDelete} />)
@@ -110,7 +151,7 @@ describe('VehicleProfile', () => {
     expect(onEdit).toHaveBeenCalledTimes(1)
   })
 
-  it('should call onDelete when Delete button is clicked', () => {
+  it('should call onDelete when the Supprimer button is clicked', () => {
     const onEdit = mock(() => {})
     const onDelete = mock(() => {})
     render(<VehicleProfile vehicle={mockVehicle} onEdit={onEdit} onDelete={onDelete} />)

--- a/apps/web/src/features/vehicles/components/VehicleProfile.tsx
+++ b/apps/web/src/features/vehicles/components/VehicleProfile.tsx
@@ -9,7 +9,7 @@ const STRIPE_BG =
 
 const KICKER_CLASSES = 'text-base-content/60 font-mono text-xs tracking-widest uppercase'
 const VALUE_CLASSES = 'text-base-content font-medium'
-const ROW_CLASSES = 'grid grid-cols-1 md:grid-cols-2 md:gap-x-8'
+const SPEC_LIST_CLASSES = 'grid grid-cols-1 md:grid-cols-2 md:gap-x-8'
 const CELL_CLASSES = 'border-base-300 border-b py-4'
 
 export interface VehicleProfileProps {
@@ -52,8 +52,6 @@ export const VehicleProfile = ({ vehicle, onEdit, onDelete }: VehicleProfileProp
       </header>
 
       <div
-        role='presentation'
-        aria-hidden='true'
         className={`border-base-300 bg-base-300/30 flex h-56 items-center justify-center border ${STRIPE_BG}`}
       >
         <span className='text-base-content/50 font-mono text-xs tracking-widest uppercase'>
@@ -61,26 +59,16 @@ export const VehicleProfile = ({ vehicle, onEdit, onDelete }: VehicleProfileProp
         </span>
       </div>
 
-      <dl role='list' className='flex flex-col'>
-        <div className={ROW_CLASSES}>
-          <SpecCell label='Marque' value={vehicle.make} />
-          <SpecCell label='Modèle' value={vehicle.model} />
-        </div>
-        <div className={ROW_CLASSES}>
-          <SpecCell label='Année' value={vehicle.year} />
-          <SpecCell label='Type moteur' value={vehicle.engineType ?? '-'} />
-        </div>
-        <div className={ROW_CLASSES}>
-          <SpecCell label='Carburant' value={fuelTypeLabel} />
-          <SpecCell label='VIN' value={vehicle.vin ?? '-'} />
-        </div>
-        <div className={ROW_CLASSES}>
-          <SpecCell label='Plaque' value={vehicle.licensePlate ?? '-'} />
-          <SpecCell label="Date d'achat" value={purchaseDateLabel} />
-        </div>
-        <div className={ROW_CLASSES}>
-          <SpecCell label='Kilométrage' value={formatMileage(vehicle.mileage)} />
-        </div>
+      <dl role='list' className={SPEC_LIST_CLASSES}>
+        <SpecCell label='Marque' value={vehicle.make} />
+        <SpecCell label='Modèle' value={vehicle.model} />
+        <SpecCell label='Année' value={vehicle.year} />
+        <SpecCell label='Type moteur' value={vehicle.engineType ?? '-'} />
+        <SpecCell label='Carburant' value={fuelTypeLabel} />
+        <SpecCell label='VIN' value={vehicle.vin ?? '-'} />
+        <SpecCell label='Plaque' value={vehicle.licensePlate ?? '-'} />
+        <SpecCell label="Date d'achat" value={purchaseDateLabel} />
+        <SpecCell label='Kilométrage' value={formatMileage(vehicle.mileage)} />
       </dl>
 
       <p id='delete-vehicle-warning' className='sr-only'>

--- a/apps/web/src/features/vehicles/components/VehicleProfile.tsx
+++ b/apps/web/src/features/vehicles/components/VehicleProfile.tsx
@@ -4,55 +4,101 @@ import type { Vehicle } from '../types'
 import { FUEL_TYPE_LABELS } from '../types'
 import { formatDate, formatMileage } from '../utils'
 
+const STRIPE_BG =
+  'bg-[repeating-linear-gradient(45deg,_transparent_0_8px,_rgba(255,255,255,0.04)_8px_16px)]'
+
+const KICKER_CLASSES = 'text-base-content/60 font-mono text-xs tracking-widest uppercase'
+const VALUE_CLASSES = 'text-base-content font-medium'
+const ROW_CLASSES = 'grid grid-cols-1 md:grid-cols-2 md:gap-x-8'
+const CELL_CLASSES = 'border-base-300 border-b py-4'
+
 export interface VehicleProfileProps {
   vehicle: Vehicle
   onEdit: () => void
   onDelete: () => void
 }
 
+const composeSubLine = (year: number, engineType: string | null): string =>
+  engineType ? `— ${year} · ${engineType}` : `— ${year}`
+
+interface SpecCellProps {
+  label: string
+  value: string | number
+}
+
+const SpecCell = ({ label, value }: SpecCellProps) => (
+  <div className={CELL_CLASSES}>
+    <dt className={KICKER_CLASSES}>{label}</dt>
+    <dd className={VALUE_CLASSES}>{value}</dd>
+  </div>
+)
+
 export const VehicleProfile = ({ vehicle, onEdit, onDelete }: VehicleProfileProps) => {
   const fuelTypeLabel = vehicle.fuelType ? FUEL_TYPE_LABELS[vehicle.fuelType] : '-'
+  const purchaseDateLabel = vehicle.purchaseDate ? formatDate(vehicle.purchaseDate) : '-'
 
   return (
-    <article className='card bg-base-200'>
-      <section className='card-body gap-4'>
-        <dl className='grid grid-cols-2 gap-x-8 gap-y-1' role='list'>
-          <dt className='text-base-content/70 text-sm'>Marque</dt>
-          <dd className='text-base-content mb-3 font-medium'>{vehicle.make}</dd>
+    <article className='border-base-300 bg-base-200 flex flex-col gap-6 border p-6'>
+      <header className='flex flex-col gap-2'>
+        <p className='text-base-content/60 font-mono text-xs tracking-widest uppercase'>
+          Fiche véhicule
+        </p>
+        <h1 className='font-display text-4xl tracking-tight md:text-5xl'>
+          {vehicle.make} {vehicle.model}
+        </h1>
+        <p className='text-primary font-mono text-sm'>
+          {composeSubLine(vehicle.year, vehicle.engineType)}
+        </p>
+      </header>
 
-          <dt className='text-base-content/70 text-sm'>Modèle</dt>
-          <dd className='text-base-content mb-3 font-medium'>{vehicle.model}</dd>
+      <div
+        role='presentation'
+        aria-hidden='true'
+        className={`border-base-300 bg-base-300/30 flex h-56 items-center justify-center border ${STRIPE_BG}`}
+      >
+        <span className='text-base-content/50 font-mono text-xs tracking-widest uppercase'>
+          [ Dans les cartons ]
+        </span>
+      </div>
 
-          <dt className='text-base-content/70 text-sm'>Année</dt>
-          <dd className='text-base-content mb-3 font-medium'>{vehicle.year}</dd>
+      <dl role='list' className='flex flex-col'>
+        <div className={ROW_CLASSES}>
+          <SpecCell label='Marque' value={vehicle.make} />
+          <SpecCell label='Modèle' value={vehicle.model} />
+        </div>
+        <div className={ROW_CLASSES}>
+          <SpecCell label='Année' value={vehicle.year} />
+          <SpecCell label='Type moteur' value={vehicle.engineType ?? '-'} />
+        </div>
+        <div className={ROW_CLASSES}>
+          <SpecCell label='Carburant' value={fuelTypeLabel} />
+          <SpecCell label='VIN' value={vehicle.vin ?? '-'} />
+        </div>
+        <div className={ROW_CLASSES}>
+          <SpecCell label='Plaque' value={vehicle.licensePlate ?? '-'} />
+          <SpecCell label="Date d'achat" value={purchaseDateLabel} />
+        </div>
+        <div className={ROW_CLASSES}>
+          <SpecCell label='Kilométrage' value={formatMileage(vehicle.mileage)} />
+        </div>
+      </dl>
 
-          <dt className='text-base-content/70 text-sm'>Type de moteur</dt>
-          <dd className='text-base-content mb-3 font-medium'>{vehicle.engineType ?? '-'}</dd>
+      <p id='delete-vehicle-warning' className='sr-only'>
+        Cette action est irréversible
+      </p>
 
-          <dt className='text-base-content/70 text-sm'>Type de carburant</dt>
-          <dd className='text-base-content mb-3 font-medium'>{fuelTypeLabel}</dd>
-
-          <dt className='text-base-content/70 text-sm'>VIN</dt>
-          <dd className='text-base-content mb-3 font-medium'>{vehicle.vin ?? '-'}</dd>
-
-          <dt className='text-base-content/70 text-sm'>Plaque d'immatriculation</dt>
-          <dd className='text-base-content mb-3 font-medium'>{vehicle.licensePlate ?? '-'}</dd>
-
-          <dt className='text-base-content/70 text-sm'>Date d'achat</dt>
-          <dd className='text-base-content mb-3 font-medium'>
-            {vehicle.purchaseDate ? formatDate(vehicle.purchaseDate) : '-'}
-          </dd>
-
-          <dt className='text-base-content/70 text-sm'>Kilométrage</dt>
-          <dd className='text-base-content mb-3 font-medium'>{formatMileage(vehicle.mileage)}</dd>
-        </dl>
-
-        <section className='card-actions justify-between'>
-          <Button onClick={onEdit}>Modifier</Button>
-          <Button onClick={onDelete} variant='destructive'>
-            Supprimer
-          </Button>
-        </section>
+      <section className='flex flex-wrap gap-3'>
+        <Button className='w-full md:w-auto' onClick={onEdit}>
+          Modifier fiche
+        </Button>
+        <Button
+          aria-describedby='delete-vehicle-warning'
+          className='btn-outline w-full md:w-auto'
+          onClick={onDelete}
+          variant='destructive'
+        >
+          Supprimer
+        </Button>
       </section>
     </article>
   )

--- a/apps/web/src/features/vehicles/components/index.ts
+++ b/apps/web/src/features/vehicles/components/index.ts
@@ -1,5 +1,7 @@
 export { DeleteVehicleDialog } from './DeleteVehicleDialog'
 export type { DeleteVehicleDialogProps } from './DeleteVehicleDialog'
+export { MileageHistoryCard } from './MileageHistoryCard'
+export type { MileageHistoryCardProps } from './MileageHistoryCard'
 export { QuickMileageUpdate } from './QuickMileageUpdate'
 export type { QuickMileageUpdateProps } from './QuickMileageUpdate'
 export { VehicleContainer } from './VehicleContainer'

--- a/apps/web/src/features/vehicles/hooks/index.ts
+++ b/apps/web/src/features/vehicles/hooks/index.ts
@@ -1,2 +1,4 @@
+export { useMileageHistory } from './useMileageHistory'
+export type { UseMileageHistoryReturn } from './useMileageHistory'
 export { useVehicle } from './useVehicle'
 export type { UseVehicleReturn } from './useVehicle'

--- a/apps/web/src/features/vehicles/hooks/useMileageHistory.spec.ts
+++ b/apps/web/src/features/vehicles/hooks/useMileageHistory.spec.ts
@@ -1,0 +1,92 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+
+import { act, renderHook } from '~/test-utils'
+
+import { $mileageHistoryTick } from '../store'
+import type { MileageHistoryEntry } from '../utils'
+
+import { useMileageHistory } from './useMileageHistory'
+
+const buildEntry = (overrides: Partial<MileageHistoryEntry> = {}): MileageHistoryEntry => ({
+  recordedAt: '2026-04-26T10:00:00.000Z',
+  mileage: 100,
+  delta: 10,
+  ...overrides
+})
+
+describe('useMileageHistory', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+    act(() => {
+      $mileageHistoryTick.set(0)
+    })
+  })
+
+  afterEach(() => {
+    window.localStorage.clear()
+    act(() => {
+      $mileageHistoryTick.set(0)
+    })
+  })
+
+  it('should return an empty entries array for a fresh vehicleId', () => {
+    const { result } = renderHook(() => useMileageHistory('v-fresh'))
+
+    expect(result.current.entries).toEqual([])
+  })
+
+  it('should append an entry, persist it, and re-render with the new entry', () => {
+    const { result } = renderHook(() => useMileageHistory('v1'))
+    const entry = buildEntry()
+
+    act(() => {
+      result.current.append(entry)
+    })
+
+    expect(result.current.entries).toEqual([entry])
+    const stored = window.localStorage.getItem('mileage-history:v1')
+    expect(stored).not.toBeNull()
+    expect(JSON.parse(stored as string)).toEqual([entry])
+  })
+
+  it('should keep histories isolated per vehicleId', () => {
+    const v1Hook = renderHook(() => useMileageHistory('v1'))
+    const v2Hook = renderHook(() => useMileageHistory('v2'))
+
+    act(() => {
+      v1Hook.result.current.append(buildEntry({ mileage: 100 }))
+    })
+    act(() => {
+      v2Hook.result.current.append(buildEntry({ mileage: 999 }))
+    })
+
+    expect(v1Hook.result.current.entries.map(entry => entry.mileage)).toEqual([100])
+    expect(v2Hook.result.current.entries.map(entry => entry.mileage)).toEqual([999])
+  })
+
+  it('should return an empty entries array and a no-op append when vehicleId is undefined', () => {
+    const { result } = renderHook(() => useMileageHistory(undefined))
+
+    expect(result.current.entries).toEqual([])
+
+    act(() => {
+      result.current.append(buildEntry())
+    })
+
+    expect(result.current.entries).toEqual([])
+    expect(window.localStorage.length).toBe(0)
+  })
+
+  it('should propagate appends across hook instances via the tick atom', () => {
+    const reader = renderHook(() => useMileageHistory('v-shared'))
+    const writer = renderHook(() => useMileageHistory('v-shared'))
+
+    expect(reader.result.current.entries).toEqual([])
+
+    act(() => {
+      writer.result.current.append(buildEntry({ mileage: 555 }))
+    })
+
+    expect(reader.result.current.entries.map(entry => entry.mileage)).toEqual([555])
+  })
+})

--- a/apps/web/src/features/vehicles/hooks/useMileageHistory.ts
+++ b/apps/web/src/features/vehicles/hooks/useMileageHistory.ts
@@ -1,0 +1,28 @@
+import { useStore } from '@nanostores/react'
+import { useCallback, useMemo } from 'react'
+
+import { $mileageHistoryTick, bumpMileageHistoryTick } from '../store'
+import { appendMileageHistory as appendUtil, getMileageHistory } from '../utils'
+import type { MileageHistoryEntry } from '../utils'
+
+export interface UseMileageHistoryReturn {
+  entries: MileageHistoryEntry[]
+  append: (entry: MileageHistoryEntry) => void
+}
+
+export const useMileageHistory = (vehicleId: string | undefined): UseMileageHistoryReturn => {
+  const tick = useStore($mileageHistoryTick)
+
+  const entries = useMemo(() => (vehicleId ? getMileageHistory(vehicleId) : []), [vehicleId, tick])
+
+  const append = useCallback(
+    (entry: MileageHistoryEntry) => {
+      if (!vehicleId) return
+      appendUtil(vehicleId, entry)
+      bumpMileageHistoryTick()
+    },
+    [vehicleId]
+  )
+
+  return { entries, append }
+}

--- a/apps/web/src/features/vehicles/store/index.ts
+++ b/apps/web/src/features/vehicles/store/index.ts
@@ -1,3 +1,4 @@
+export { $mileageHistoryTick, bumpMileageHistoryTick } from './mileageHistory.store'
 export {
   $error,
   $hasVehicle,

--- a/apps/web/src/features/vehicles/store/mileageHistory.store.ts
+++ b/apps/web/src/features/vehicles/store/mileageHistory.store.ts
@@ -1,0 +1,7 @@
+import { atom } from 'nanostores'
+
+export const $mileageHistoryTick = atom<number>(0)
+
+export const bumpMileageHistoryTick = (): void => {
+  $mileageHistoryTick.set($mileageHistoryTick.get() + 1)
+}

--- a/apps/web/src/features/vehicles/utils/formatMileage.spec.ts
+++ b/apps/web/src/features/vehicles/utils/formatMileage.spec.ts
@@ -3,15 +3,15 @@ import { describe, expect, it } from 'bun:test'
 import { formatMileage } from './formatMileage'
 
 describe('formatMileage', () => {
-  it('should return singular km for 0', () => {
+  it('should return invariant km for 0', () => {
     expect(formatMileage(0)).toBe('0 km')
   })
 
-  it('should return singular km for 1', () => {
+  it('should return invariant km for 1', () => {
     expect(formatMileage(1)).toBe('1 km')
   })
 
-  it('should return plural kms for values > 1', () => {
-    expect(formatMileage(2)).toBe('2 kms')
+  it('should return invariant km for values > 1', () => {
+    expect(formatMileage(2)).toBe('2 km')
   })
 })

--- a/apps/web/src/features/vehicles/utils/formatMileage.ts
+++ b/apps/web/src/features/vehicles/utils/formatMileage.ts
@@ -1,1 +1,1 @@
-export const formatMileage = (mileage: number): string => `${mileage} km${mileage > 1 ? 's' : ''}`
+export const formatMileage = (mileage: number): string => `${mileage} km`

--- a/apps/web/src/features/vehicles/utils/index.ts
+++ b/apps/web/src/features/vehicles/utils/index.ts
@@ -1,2 +1,4 @@
 export { formatDate } from './formatDate'
 export { formatMileage } from './formatMileage'
+export { appendMileageHistory, getMileageHistory } from './mileageHistory.utils'
+export type { MileageHistoryEntry } from './mileageHistory.utils'

--- a/apps/web/src/features/vehicles/utils/mileageHistory.utils.spec.ts
+++ b/apps/web/src/features/vehicles/utils/mileageHistory.utils.spec.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from 'bun:test'
+
+import type { MileageHistoryEntry } from './mileageHistory.utils'
+import { appendMileageHistory, getMileageHistory } from './mileageHistory.utils'
+
+const VEHICLE_ID = 'v1'
+const KEY = `mileage-history:${VEHICLE_ID}`
+
+const buildEntry = (overrides: Partial<MileageHistoryEntry> = {}): MileageHistoryEntry => ({
+  recordedAt: '2026-04-26T10:00:00.000Z',
+  mileage: 100,
+  delta: 10,
+  ...overrides
+})
+
+describe('mileageHistory.utils', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+  })
+
+  afterEach(() => {
+    window.localStorage.clear()
+  })
+
+  describe('getMileageHistory', () => {
+    it('should return an empty array when no key exists', () => {
+      expect(getMileageHistory(VEHICLE_ID)).toEqual([])
+    })
+
+    it('should return the parsed array for valid JSON', () => {
+      const entries = [buildEntry({ mileage: 200 }), buildEntry({ mileage: 100 })]
+      window.localStorage.setItem(KEY, JSON.stringify(entries))
+
+      expect(getMileageHistory(VEHICLE_ID)).toEqual(entries)
+    })
+
+    it('should return an empty array and warn when JSON is malformed', () => {
+      const warn = spyOn(console, 'warn').mockImplementation(mock(() => {}))
+      window.localStorage.setItem(KEY, '{not-json')
+
+      expect(getMileageHistory(VEHICLE_ID)).toEqual([])
+      expect(warn).toHaveBeenCalled()
+
+      warn.mockRestore()
+    })
+
+    it('should return an empty array when stored value is not an array', () => {
+      window.localStorage.setItem(KEY, JSON.stringify({ not: 'an array' }))
+
+      expect(getMileageHistory(VEHICLE_ID)).toEqual([])
+    })
+
+    it('should keep histories isolated per vehicleId', () => {
+      const v1Entries = [buildEntry({ mileage: 100 })]
+      const v2Entries = [buildEntry({ mileage: 999 })]
+      window.localStorage.setItem('mileage-history:v1', JSON.stringify(v1Entries))
+      window.localStorage.setItem('mileage-history:v2', JSON.stringify(v2Entries))
+
+      expect(getMileageHistory('v1')).toEqual(v1Entries)
+      expect(getMileageHistory('v2')).toEqual(v2Entries)
+    })
+  })
+
+  describe('appendMileageHistory', () => {
+    it('should write valid JSON to localStorage', () => {
+      const entry = buildEntry()
+
+      appendMileageHistory(VEHICLE_ID, entry)
+
+      const raw = window.localStorage.getItem(KEY)
+      expect(raw).not.toBeNull()
+      expect(JSON.parse(raw as string)).toEqual([entry])
+    })
+
+    it('should order entries most-recent-first', () => {
+      const first = buildEntry({ mileage: 100, recordedAt: '2026-04-26T08:00:00.000Z' })
+      const second = buildEntry({ mileage: 200, recordedAt: '2026-04-26T10:00:00.000Z' })
+
+      appendMileageHistory(VEHICLE_ID, first)
+      appendMileageHistory(VEHICLE_ID, second)
+
+      expect(getMileageHistory(VEHICLE_ID)).toEqual([second, first])
+    })
+
+    it('should cap stored entries at 20 (drops oldest)', () => {
+      for (let i = 0; i < 25; i = i + 1) {
+        appendMileageHistory(VEHICLE_ID, buildEntry({ mileage: i }))
+      }
+
+      const stored = getMileageHistory(VEHICLE_ID)
+      expect(stored).toHaveLength(20)
+      expect(stored[0]?.mileage).toBe(24)
+      expect(stored[19]?.mileage).toBe(5)
+    })
+  })
+})

--- a/apps/web/src/features/vehicles/utils/mileageHistory.utils.ts
+++ b/apps/web/src/features/vehicles/utils/mileageHistory.utils.ts
@@ -28,5 +28,9 @@ export const appendMileageHistory = (vehicleId: string, entry: MileageHistoryEnt
   if (typeof window === 'undefined') return
 
   const next = [entry, ...getMileageHistory(vehicleId)].slice(0, MAX_ENTRIES)
-  window.localStorage.setItem(storageKey(vehicleId), JSON.stringify(next))
+  try {
+    window.localStorage.setItem(storageKey(vehicleId), JSON.stringify(next))
+  } catch (error) {
+    console.warn(`mileageHistory: failed to persist history for ${vehicleId}`, error)
+  }
 }

--- a/apps/web/src/features/vehicles/utils/mileageHistory.utils.ts
+++ b/apps/web/src/features/vehicles/utils/mileageHistory.utils.ts
@@ -1,0 +1,32 @@
+export interface MileageHistoryEntry {
+  recordedAt: string
+  mileage: number
+  delta: number
+}
+
+const MAX_ENTRIES = 20
+
+const storageKey = (vehicleId: string): string => `mileage-history:${vehicleId}`
+
+export const getMileageHistory = (vehicleId: string): MileageHistoryEntry[] => {
+  if (typeof window === 'undefined') return []
+
+  const raw = window.localStorage.getItem(storageKey(vehicleId))
+  if (!raw) return []
+
+  try {
+    const parsed = JSON.parse(raw)
+    if (!Array.isArray(parsed)) return []
+    return parsed
+  } catch (error) {
+    console.warn(`mileageHistory: failed to parse stored history for ${vehicleId}`, error)
+    return []
+  }
+}
+
+export const appendMileageHistory = (vehicleId: string, entry: MileageHistoryEntry): void => {
+  if (typeof window === 'undefined') return
+
+  const next = [entry, ...getMileageHistory(vehicleId)].slice(0, MAX_ENTRIES)
+  window.localStorage.setItem(storageKey(vehicleId), JSON.stringify(next))
+}

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -84,6 +84,16 @@ shape are NOT listed here — they live in the shape.
       each update — no historical signal exists today. Defer until Visual Refresh ships
       (frontend-only contract per `docs/features/09-visual-refresh.md`).
 
+## UI / dialog button consistency (post Visual Refresh)
+
+- [ ] **`ConfirmDialog` action buttons full-width on mobile** — currently `Annuler` / confirm
+      buttons inside `<div className='modal-action'>` keep their natural width even on small
+      viewports, which is inconsistent with the in-page action buttons that all expand to
+      `w-full md:w-auto` since Block 3 (Vehicles). Touching `ConfirmDialog` cascades on every
+      consumer (`DeleteVehicleDialog`, `DeleteCheckTypeDialog`, `DeleteCheckLogDialog`,
+      `DeleteExpenseDialog`, `DeleteBudgetDialog`, `DeleteAccountDialog`, `ResetPasswordDialog`,
+      etc.) — defer to a dedicated cross-feature pass once the visual refresh ships.
+
 ## Documentation (optional, future)
 
 - [ ] Consider adding a short "About this document" blurb to `docs/MVP.md` and to each feature shape

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -103,43 +103,50 @@ Current state only. Deferred items live in [`BACKLOG.md`](./BACKLOG.md).
       `useAuth.ts:76` mapping `name: data.username`); `pages/profile/sessions.astro` lightly
       polished as a side-effect of `SessionList` testing — full Phase 23 refresh still pending
 
-### Block 3: Vehicles — `feature/visual-refresh-vehicles`
+### Block 3: Vehicles — `feature/visual-refresh-vehicles` ✅
 
 #### Phase 10: `VehicleProfile` + `QuickMileageUpdate` + `VehicleContainer` + new `MileageHistoryCard` + history utilities
 
-- [ ] `VehicleProfile.tsx` restructured per the mockup `Profil véhicule (vue)` (Image #3): kicker
+- [x] `VehicleProfile.tsx` restructured per the mockup `Profil véhicule (vue)` (Image #3): kicker
       `Fiche véhicule`, h1 display `{make} {model}`, composed sub line `— {year} · {engineType}`
       (handles `engineType === null`), striped photo placeholder, mono uppercase `<dt>` kickers +
       sans-serif `<dd>` grid, footer with `Modifier fiche` and `Supprimer` (the latter carries
       `aria-describedby` to a `.sr-only` warning)
-- [ ] `QuickMileageUpdate.tsx` rebuilt as `COMPTEUR KILOMÉTRIQUE` card: kicker, inner panel with
+- [x] `QuickMileageUpdate.tsx` rebuilt as `COMPTEUR KILOMÉTRIQUE` card: kicker, inner panel with
       current km in `font-mono text-primary` + label, `Nouvelle valeur` input (`font-mono text-lg`),
       live delta below when watched value `> currentMileage`, full-width `Valider` button — copy
       change `Mettre à jour` → `Valider`
-- [ ] `VehicleContainer.tsx`: view mode renders `lg:grid-cols-3` with `lg:col-span-2` profile +
+- [x] `VehicleContainer.tsx`: view mode renders `lg:grid-cols-3` with `lg:col-span-2` profile +
       `<aside lg:col-span-1>` stack (compteur + history); standalone `<h1>` dropped in view mode
       (lives in `VehicleProfile`); cluster kickers above create / edit form cards; nested
       `max-w-2xl` wrappers removed across the 3 modes; mileage-history `append` wired after each
-      successful `updateMileage`
-- [ ] New `MileageHistoryCard.tsx` + spec — kicker, empty state mono dimmed, populated entries 3-col
-      grid (`<time>` · mileage · `+ delta`)
-- [ ] New `useMileageHistory.ts` hook + spec, `mileageHistory.utils.ts` + spec, and atom-only
+      successful `updateMileage` (only when `delta > 0`)
+- [x] New `MileageHistoryCard.tsx` + spec — kicker, empty state mono dimmed, populated entries 3-col
+      grid (`<time>` · mileage · `+ delta`), capped at 10 visible
+- [x] New `useMileageHistory.ts` hook + spec, `mileageHistory.utils.ts` + spec, and atom-only
       `mileageHistory.store.ts` — frontend-only stub backed by `localStorage` keyed
       `mileage-history:{vehicleId}`, capped at 20 entries (the real cross-device backend feature
       lives in `BACKLOG.md` as `Mileage Log`, post-Visual-Refresh)
-- [ ] Spec updates: `VehicleContainer` view-mode h1 assertion split (year moves to sub line),
+- [x] Spec updates: `VehicleContainer` view-mode h1 assertion split (year moves to sub line),
       `Valider` / `Nouvelle valeur` copy adjustments, `toHaveAccessibleDescription` on delete,
-      `MileageHistoryCard` empty state assertion
+      `MileageHistoryCard` empty state assertion + populated history after submit
 
 #### Phase 11: `VehicleForm` + `DeleteVehicleDialog` + `VehicleEmptyState` + specs
 
-- [ ] `VehicleForm.tsx`: daisy `fieldset` / `fieldset-legend` classes replaced with cluster mono
+- [x] `VehicleForm.tsx`: daisy `fieldset` / `fieldset-legend` classes replaced with cluster mono
       uppercase typography on legends; kilométrage input gets `font-mono text-lg` for the odometer
       screen look
-- [ ] `DeleteVehicleDialog.tsx`: no code change — inherits the cluster `ConfirmDialog` already
+- [x] `DeleteVehicleDialog.tsx`: no code change — inherits the cluster `ConfirmDialog` already
       shipped in Block 1; verification only
-- [ ] `VehicleEmptyState.tsx`: cluster kicker `Créer votre fiche` above the icon, mono dimmed body,
+- [x] `VehicleEmptyState.tsx`: cluster kicker `Créer votre fiche` above the icon, mono dimmed body,
       primary amber CTA
+
+#### Block 3 implementation notes
+
+- `VehicleProfile` destructive button uses `className='btn-outline'` locally (option b in the plan)
+  to keep the change surgical; existing `Button` `destructive` variant remains solid `btn-error` and
+  unchanged for the rest of the codebase. Same pattern used for the cancel buttons in
+  `VehicleContainer` create/edit modes.
 
 ### Block 4: Checks (Types + Logs) — `feature/visual-refresh-checks`
 


### PR DESCRIPTION
## Summary

Block 3 of Feature 09 (Visual Refresh) — Phases 10 and 11. Frontend-only, zero backend changes.

- Cluster restyle of `VehicleProfile`, `QuickMileageUpdate`, `VehicleContainer`, `VehicleForm`, `VehicleEmptyState` per the V01 mockup
- New frontend-only mileage history feature (utils + atom + hook + `MileageHistoryCard`) backed by `localStorage`, capped at 20 entries per vehicle, surfaced beside the compteur on `/vehicle`
- `formatMileage` simplified to invariant `${km} km` (correct French; affects 1 dashboard spec too)

## Implementation notes (worth flagging in review)

- **Destructive button outline**: `VehicleProfile`'s `Supprimer` and `VehicleContainer` cancel buttons use `className='btn-outline'` locally rather than extending the `Button` `destructive` variant project-wide — option (b) of the plan, deliberate, documented in `PROGRESS.md`. Promote to a `destructive-outline` variant if a 4th occurrence appears in later blocks.
- **Mileage history reactivity**: cross-instance sync goes through a single `$mileageHistoryTick` atom in `vehicles/store/mileageHistory.store.ts`. Real cross-device storage is parked in `BACKLOG.md` as `Mileage Log feature` (backend `MileageLog` entity + Prisma migration, post Visual Refresh).
- **Async error surfaces**: `handleQuickMileageSubmit` now wraps in `try/catch` and surfaces failures via a new `serverError` banner in view mode. Side benefit — this also fixes a pre-existing silent gap on `onDelete` (its `serverError` had no UI surface before).
- **`useMileageHistory(vehicleId: string | undefined)`**: takes optional `vehicleId` and short-circuits when undefined, removing the `'unknown'` magic string from the call site.
- **Mobile button consistency**: every in-page action button is `w-full md:w-auto`. The `ConfirmDialog` action buttons (used by `DeleteVehicleDialog` and 6+ other delete dialogs across the app) are NOT updated here — the change cascades cross-feature, deferred to backlog.

## Commits (10)

1. `2d0fc44` refactor(web:vehicles): drop plural suffix from formatMileage
2. `4f0c7b1` feat(web:vehicles): add mileage history utilities
3. `8684fcb` feat(web:vehicles): add mileage history tick atom
4. `0af099e` feat(web:vehicles): add useMileageHistory hook
5. `7bb0460` feat(web:vehicles): add MileageHistoryCard component
6. `e0b5e2c` refactor(web:vehicles): refresh VehicleProfile to cluster layout
7. `7fa75be` refactor(web:vehicles): refresh QuickMileageUpdate to cluster layout
8. `35705ac` refactor(web:vehicles): rework VehicleContainer layout and wire mileage history
9. `324eea0` refactor(web:vehicles): refresh VehicleForm and VehicleEmptyState to cluster style
10. `be69ac1` docs(progress): mark Block 3 vehicles complete and log ConfirmDialog backlog

## Test plan

- [x] `/vehicle` view mode at desktop ≥ 1024px renders 2/3 + 1/3 grid (profile + aside compteur + history)
- [x] Submit a higher mileage value → live `+ delta km` shows during typing → on submit, history populates with one entry, persists across reload
- [x] Mobile (320px) → single-column stack, no horizontal scroll, action buttons full-width
- [x] Each spec row in `VehicleProfile` carries its own `border-b py-4` (broken across the column gap on desktop)
- [x] Photo placeholder reads `[ Dans les cartons ]`; spec labels are `Type moteur`, `Carburant`, `Plaque`
- [x] Failing `updateMileage` (e.g. offline) surfaces the error banner above the grid
- [x] Delete from view mode → cluster `ConfirmDialog`, outline `Annuler`, destructive `Supprimer`
- [x] Empty state at `/vehicle` (delete current vehicle) → kicker + dimmed icon + amber CTA
- [x] Create / edit modes show cluster header above the form card; cancel returns to view/empty

## Linked plan

`~/.claude/plans/car-cost-tracker-09-visual-refresh.md` — Block 3 (Phases 10-11)