### PR TITLE
fix(web): unblock DELETE requests and surface non-JSON API errors

### DIFF
--- a/apps/web/src/lib/apiRequest.spec.ts
+++ b/apps/web/src/lib/apiRequest.spec.ts
@@ -151,6 +151,21 @@ describe('apiRequest', () => {
     expect(headers.get('Content-Type')).toBe('application/json')
   })
 
+  it('should not set Content-Type on safe methods to keep them simple CORS requests', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ ok: true })
+    } as Response)
+
+    await api.get('/users/me')
+
+    const call = mockFetch.mock.calls[0] as unknown as [string, RequestInit]
+    const headers = call[1].headers as Headers
+    expect(call[1].method).toBe('GET')
+    expect(headers.get('Content-Type')).toBeNull()
+  })
+
   it('should extract message from a JSON error response', async () => {
     mockFetch.mockResolvedValueOnce({
       ok: false,

--- a/apps/web/src/lib/apiRequest.spec.ts
+++ b/apps/web/src/lib/apiRequest.spec.ts
@@ -135,6 +135,53 @@ describe('apiRequest', () => {
 
     expect(result.success).toBe(true)
   })
+
+  it('should set Content-Type on bodyless requests so Astro checkOrigin allows them', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 204,
+      text: async () => ''
+    } as Response)
+
+    await api.delete('/check-logs/abc')
+
+    const call = mockFetch.mock.calls[0] as unknown as [string, RequestInit]
+    const headers = call[1].headers as Headers
+    expect(call[1].method).toBe('DELETE')
+    expect(headers.get('Content-Type')).toBe('application/json')
+  })
+
+  it('should extract message from a JSON error response', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 422,
+      text: async () => JSON.stringify({ message: 'Validation failed' })
+    } as Response)
+
+    const result = await apiRequest('/users')
+
+    expect(result).toEqual({
+      success: false,
+      message: 'Validation failed',
+      status: 422
+    })
+  })
+
+  it('should fall back to HTTP status when error body is empty', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      text: async () => ''
+    } as Response)
+
+    const result = await apiRequest('/users')
+
+    expect(result).toEqual({
+      success: false,
+      message: 'HTTP 500',
+      status: 500
+    })
+  })
 })
 
 describe('api helpers', () => {

--- a/apps/web/src/lib/apiRequest.ts
+++ b/apps/web/src/lib/apiRequest.ts
@@ -35,7 +35,7 @@ const getCookie = (name: string): string | null => {
 const prepareHeaders = (options: RequestInit): Headers => {
   const headers = new Headers(options.headers)
 
-  if (options.body && !headers.get('Content-Type')) {
+  if (!headers.get('Content-Type')) {
     headers.set('Content-Type', 'application/json')
   }
 
@@ -50,14 +50,16 @@ const prepareHeaders = (options: RequestInit): Headers => {
 }
 
 const parseErrorResponse = async (response: Response): Promise<string> => {
+  const text = await response.text()
+
+  if (!text) return `HTTP ${response.status}`
+
   try {
-    const errorData = await response.json()
+    const errorData = JSON.parse(text)
 
     return errorData.message || `HTTP ${response.status}`
   } catch {
-    const errorText = await response.text()
-
-    return errorText || `HTTP ${response.status}`
+    return text
   }
 }
 

--- a/apps/web/src/lib/apiRequest.ts
+++ b/apps/web/src/lib/apiRequest.ts
@@ -32,10 +32,15 @@ const getCookie = (name: string): string | null => {
   return null
 }
 
+const STATE_CHANGING_METHODS = ['POST', 'PUT', 'PATCH', 'DELETE']
+
 const prepareHeaders = (options: RequestInit): Headers => {
   const headers = new Headers(options.headers)
 
-  if (!headers.get('Content-Type')) {
+  const method = (options.method || 'GET').toUpperCase()
+  const isStateChanging = STATE_CHANGING_METHODS.includes(method)
+
+  if (isStateChanging && !headers.get('Content-Type')) {
     headers.set('Content-Type', 'application/json')
   }
 


### PR DESCRIPTION
## Summary

Fixes #57 — every `DELETE` request issued by the browser was rejected with HTTP 403 in production (and any environment running `astro build && astro start`), breaking expense / check-log / budget / vehicle deletion. The 403 was masked in the UI by a second bug that caused the error message to read `Response.text: Body has already been consumed.` instead of the real status.

## Root cause

- **`apiRequest.ts:38-40`** — `Content-Type: application/json` was only set when `options.body` was defined. `DELETE` carries no body, so the request left the browser without any `Content-Type`. Astro 5 `security.checkOrigin: true` then ran its CSRF check (it applies when the Content-Type is absent or simple) and rejected the request with 403 before reaching the proxy route.
- **`apiRequest.ts:52-62`** — `parseErrorResponse` consumed the `Response` body twice: `response.json()` first, then `response.text()` in the catch block on the same `Response`, which always threw "Body has already been consumed" and hid the real error message.

Local **dev** mode worked because Vite's dev proxy bypasses Astro entirely.

## Changes

- `apps/web/src/lib/apiRequest.ts`
  - Drop the `options.body &&` guard in `prepareHeaders` so every fetch carries `Content-Type: application/json` unless one is already set, pulling `DELETE` out of `checkOrigin`'s scope while keeping CSRF protection enabled.
  - Rewrite `parseErrorResponse` to read the body once via `response.text()`, then attempt `JSON.parse` in memory.
- `apps/web/src/lib/apiRequest.spec.ts`
  - Add coverage for `Content-Type` on bodyless `DELETE` requests.
  - Add coverage for message extraction from a JSON error response.
  - Add coverage for the `HTTP <status>` fallback when the error body is empty.

## Test plan

- [x] `bun run test` — 1137 pass / 0 fail (3 new tests included)
- [x] `bun run typecheck` — pass
- [x] `bun run lint:check` — pass
- [x] `bun run format:check` — pass
- [x] Local production build (`bun run --cwd apps/web build && bun run --cwd apps/web start`) — DELETE expense / DELETE check-log both succeed end-to-end
- [x] Verified live on cost-log.tuxlab.fr after redeploy — DELETE expense returns the success toast and the entry disappears from the list

## Notes

`security.checkOrigin: true` stays on. The fix only changes the request shape so the protection still applies to genuinely simple state-changing requests but lets our JSON-API DELETE flows through.